### PR TITLE
Fix debounce not working due to dependency issues

### DIFF
--- a/app/hooks/useExerciseFilters.ts
+++ b/app/hooks/useExerciseFilters.ts
@@ -62,7 +62,8 @@ export function useExerciseFilters({ exerciseTypes }: UseExerciseFiltersProps) {
     return () => {
       clearTimeout(timer);
     };
-  }, [searchTerm, selectedTypeIds, syncToURL]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchTerm]);
 
   // Sync selected types to URL immediately
   useEffect(() => {
@@ -70,7 +71,8 @@ export function useExerciseFilters({ exerciseTypes }: UseExerciseFiltersProps) {
       return;
     }
     syncToURL(searchTerm, selectedTypeIds);
-  }, [selectedTypeIds, searchTerm, syncToURL]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTypeIds]);
 
   // Get all child IDs for a parent type
   const getChildIds = (parentId: string): string[] => {


### PR DESCRIPTION
- Remove selectedTypeIds from search debounce effect dependencies
- Remove searchTerm from type filter effect dependencies
- Add eslint-disable comments for intentional dependency omissions
- Prevents circular dependency causing API request on every keystroke

🤖 Generated with [Claude Code](https://claude.com/claude-code)