### PR TITLE
Fix unit test failures caused by database setup issues

### DIFF
--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -1,17 +1,24 @@
 import { beforeEach, afterAll } from 'vitest';
-import { PrismaClient } from '@prisma/client';
 
-// Override DATABASE_URL for tests
+// Override DATABASE_URL for tests BEFORE importing db
 process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5436/harkka_db_test';
 
-const db = new PrismaClient();
+// Import db from the application's db singleton
+import { db } from '~/utils/db.server';
 
-// Run before each test suite
-beforeEach(async () => {
-  // Clean all tables in reverse order (respecting foreign keys)
-  await db.exercise.deleteMany({});
-  await db.exerciseTypeTranslation.deleteMany({});
-  await db.exerciseType.deleteMany({});
+// Run before each test
+beforeEach(async (context) => {
+  // Only clean database for tests that need it (skip for tests that don't use the database)
+  // Check if the test file path includes '/services/' to determine if it needs DB cleanup
+  const testPath = context.task.file?.filepath || '';
+  const needsDbCleanup = testPath.includes('/services/') || testPath.includes('\\services\\');
+
+  if (!needsDbCleanup) {
+    return;
+  }
+
+  // Clean all tables - use TRUNCATE with CASCADE for efficiency
+  await db.$executeRaw`TRUNCATE TABLE exercise_types RESTART IDENTITY CASCADE`;
 });
 
 // Run once after all tests


### PR DESCRIPTION
Updated test database setup to resolve foreign key constraint violations and test isolation problems. The test suite was failing due to:

1. Using separate PrismaClient instance instead of app's singleton
2. Cleaning database for all tests including non-database tests
3. Inefficient deletion order causing foreign key violations

Changes:
- Import db from app's singleton (~/utils/db.server) to ensure same connection
- Add conditional cleanup to only truncate database for service tests
- Use TRUNCATE with CASCADE for efficient and safe database cleanup

All 29 tests now pass consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)