### PR TITLE
Unify table column names to use snake_case

### DIFF
--- a/prisma/migrations/20251007095303_rename_session_length_to_snake_case/migration.sql
+++ b/prisma/migrations/20251007095303_rename_session_length_to_snake_case/migration.sql
@@ -1,0 +1,13 @@
+-- Rename sessionLength to session_length in section_duration_configs table
+ALTER TABLE "section_duration_configs" RENAME COLUMN "sessionLength" TO "session_length";
+
+-- Rename sessionLength to session_length in practice_sessions table
+ALTER TABLE "practice_sessions" RENAME COLUMN "sessionLength" TO "session_length";
+
+-- Drop and recreate index for section_duration_configs
+DROP INDEX IF EXISTS "section_duration_configs_sessionLength_idx";
+CREATE INDEX "section_duration_configs_session_length_idx" ON "section_duration_configs"("session_length");
+
+-- Drop and recreate unique constraint for section_duration_configs
+ALTER TABLE "section_duration_configs" DROP CONSTRAINT IF EXISTS "section_duration_configs_section_id_sessionLength_key";
+ALTER TABLE "section_duration_configs" ADD CONSTRAINT "section_duration_configs_section_id_session_length_key" UNIQUE("section_id", "session_length");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,7 +135,7 @@ model SectionDurationConfig {
   id              String   @id @default(uuid())
   section         Section  @relation(fields: [sectionId], references: [id], onDelete: Cascade)
   sectionId       String   @map("section_id")
-  sessionLength   Int
+  sessionLength   Int      @map("session_length")
   duration        Int
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
@@ -165,7 +165,7 @@ model PracticeSession {
   slug          String   @unique
   name          String?
   description   String?  @db.Text
-  sessionLength Int
+  sessionLength Int      @map("session_length")
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
 


### PR DESCRIPTION
Renamed sessionLength columns to session_length in:
- section_duration_configs table
- practice_sessions table

Updated Prisma schema to map camelCase field names to snake_case database columns, maintaining backwards compatibility in TypeScript code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)