### PR TITLE
Improve scripts documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Make sure to deploy the output of `npm run build`
 - `build/server`
 - `build/client`
 
+## Scripts
+
+The project includes several utility scripts for managing content and maintaining the database. See [scripts/README.md](./scripts/README.md) for detailed documentation.
+
+**Quick reference**:
+
+- `npm run insert-exercises -- <json-file> <type-id>` - Import exercise content
+- `npx tsx scripts/regenerate-slugs.ts` - Regenerate all slugs
+- `npx tsx scripts/test-slugs.ts` - Test slug generation
+- `npx tsx scripts/crawler/index.ts <html-file>` - Parse HTML content
+
 ## Styling
 
 This template comes with [Tailwind CSS](https://tailwindcss.com/) already configured for a simple default starting experience. You can use whatever css framework you prefer. See the [Vite docs on css](https://vitejs.dev/guide/features.html#css) for more information.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:watch": "vitest --watch",
-    "insert-exercises": "tsx scripts/insert-junnufriba-content.ts"
+    "insert-exercises": "tsx scripts/insert-content.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,152 @@
+# Scripts
+
+Utility scripts for managing the Harkkapankki application.
+
+## Available Scripts
+
+### Content Management
+
+#### `insert-content.ts`
+
+Inserts exercise content into the database from JSON files.
+
+**Purpose**: Import parsed exercise data (typically from the crawler) into the database.
+
+**Usage**:
+
+```bash
+npm run insert-exercises -- <path-to-json-file> <exercise-type-id>
+# or
+npx tsx scripts/insert-content.ts <path-to-json-file> <exercise-type-id>
+```
+
+**Parameters**:
+
+- `<path-to-json-file>`: Path to JSON file containing exercise data
+- `<exercise-type-id>`: UUID of the exercise type to associate with the exercise
+
+**JSON File Format**:
+
+```json
+{
+  "header": "Exercise Title",
+  "body": "Exercise content in markdown format with @[youtube](URL) tags..."
+}
+```
+
+**Example**:
+
+```bash
+npm run insert-exercises -- ./docs/junnufriba-crawler/parsed-data/20240115-120000/content.json abc123-def456-789
+```
+
+**Validation**: The script validates that:
+
+- JSON file contains required `header` and `body` properties
+- Exercise type ID exists in the database
+- All data is properly formatted
+
+---
+
+### Database Maintenance
+
+#### `regenerate-slugs.ts`
+
+Regenerates slugs for all exercises and practice sessions in the database.
+
+**Purpose**: Update slugs based on current names, useful after bulk imports or name changes.
+
+**Usage**:
+
+```bash
+npx tsx scripts/regenerate-slugs.ts
+```
+
+**What it does**:
+
+- Regenerates slugs for all exercises based on their names
+- Regenerates slugs for all practice sessions based on their names
+- Handles duplicate slugs by appending numeric suffixes (e.g., `exercise`, `exercise-2`, `exercise-3`)
+- Updates the database with new slugs
+
+**When to use**:
+
+- After importing exercises without proper slugs
+- After renaming multiple items
+- To ensure slug uniqueness and consistency
+
+---
+
+#### `test-slugs.ts`
+
+Tests and verifies slug generation for exercises and practice sessions.
+
+**Purpose**: Diagnostic tool to check if slugs are properly generated.
+
+**Usage**:
+
+```bash
+npx tsx scripts/test-slugs.ts
+```
+
+**Output**: Displays sample records showing:
+
+- ID
+- Name
+- Slug
+- Whether slug exists
+
+**When to use**:
+
+- To verify slugs after database operations
+- To debug slug-related issues
+- To check data integrity
+
+---
+
+### Content Crawling
+
+See [crawler/README.md](./crawler/README.md) for detailed documentation on the HTML crawler scripts.
+
+**Quick Overview**:
+
+- `crawler/index.ts` - Parses HTML files from external sources
+- `crawler/parse-html.ts` - HTML parsing and conversion logic
+
+---
+
+## Workflow Example
+
+Here's a typical workflow for importing new exercise content:
+
+1. **Parse HTML content** (if importing from external source):
+
+   ```bash
+   npx tsx scripts/crawler/index.ts docs/junnufriba-crawler/exercise.html
+   ```
+
+2. **Insert parsed content into database**:
+
+   ```bash
+   npm run insert-exercises -- docs/junnufriba-crawler/parsed-data/[timestamp]/content.json [exercise-type-id]
+   ```
+
+3. **Verify slugs** (optional):
+
+   ```bash
+   npx tsx scripts/test-slugs.ts
+   ```
+
+4. **Regenerate slugs** (if needed):
+   ```bash
+   npx tsx scripts/regenerate-slugs.ts
+   ```
+
+---
+
+## Notes
+
+- All scripts use TypeScript and require the `tsx` package to run
+- Scripts connect to the database using Prisma Client
+- Ensure your `.env` file is properly configured with `DATABASE_URL`
+- Run scripts from the project root directory

--- a/scripts/insert-content.ts
+++ b/scripts/insert-content.ts
@@ -1,3 +1,26 @@
+/**
+ * Insert Content Script
+ *
+ * Inserts exercise content into the database from JSON files.
+ *
+ * Usage:
+ *   npm run insert-exercises -- <path-to-json-file> <exercise-type-id>
+ *   npx tsx scripts/insert-content.ts <path-to-json-file> <exercise-type-id>
+ *
+ * Parameters:
+ *   - path-to-json-file: Path to JSON file containing exercise data
+ *   - exercise-type-id: UUID of the exercise type to associate with the exercise
+ *
+ * JSON Format:
+ *   {
+ *     "header": "Exercise Title",
+ *     "body": "Exercise content in markdown..."
+ *   }
+ *
+ * Example:
+ *   npm run insert-exercises -- ./docs/crawler/parsed-data/20240115/content.json abc-123-def
+ */
+
 import { PrismaClient } from '@prisma/client';
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';

--- a/scripts/regenerate-slugs.ts
+++ b/scripts/regenerate-slugs.ts
@@ -1,3 +1,23 @@
+/**
+ * Regenerate Slugs Script
+ *
+ * Regenerates slugs for all exercises and practice sessions in the database.
+ *
+ * Usage:
+ *   npx tsx scripts/regenerate-slugs.ts
+ *
+ * What it does:
+ *   - Regenerates slugs for all exercises based on their names
+ *   - Regenerates slugs for all practice sessions based on their names
+ *   - Handles duplicate slugs by appending numeric suffixes (e.g., exercise, exercise-2, exercise-3)
+ *   - Updates the database with new slugs
+ *
+ * When to use:
+ *   - After importing exercises without proper slugs
+ *   - After renaming multiple items
+ *   - To ensure slug uniqueness and consistency
+ */
+
 import { PrismaClient } from '@prisma/client';
 
 const db = new PrismaClient();

--- a/scripts/test-slugs.ts
+++ b/scripts/test-slugs.ts
@@ -1,3 +1,24 @@
+/**
+ * Test Slugs Script
+ *
+ * Tests and verifies slug generation for exercises and practice sessions.
+ *
+ * Usage:
+ *   npx tsx scripts/test-slugs.ts
+ *
+ * Output:
+ *   Displays sample records showing:
+ *   - ID
+ *   - Name
+ *   - Slug
+ *   - Whether slug exists
+ *
+ * When to use:
+ *   - To verify slugs after database operations
+ *   - To debug slug-related issues
+ *   - To check data integrity
+ */
+
 import { PrismaClient } from '@prisma/client';
 
 const db = new PrismaClient();


### PR DESCRIPTION
Enhance technical documentation for utility scripts with comprehensive usage instructions and examples.

Changes:
- Rename insert-junnufriba-content.ts to insert-content.ts for clarity
- Update package.json npm script to reference renamed file
- Create scripts/README.md with detailed documentation:
  - Overview of all available scripts
  - Usage examples and parameters
  - Workflow examples
  - When to use each script
- Add header documentation to all script files:
  - insert-content.ts: Exercise content insertion
  - regenerate-slugs.ts: Slug regeneration utility
  - test-slugs.ts: Slug testing and verification
- Update main README.md with Scripts section linking to detailed docs

Documentation now provides clear guidance for:
- Importing exercise content from JSON
- Regenerating slugs after bulk operations
- Testing slug generation
- Understanding the content import workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)