### PR TITLE
Add configurable locale support and deterministic UUIDs for exercise …

### DIFF
--- a/app/routes/exercises.$id_.edit.tsx
+++ b/app/routes/exercises.$id_.edit.tsx
@@ -12,11 +12,12 @@ import { fetchExerciseById, updateExercise, deleteExercise } from '~/services/ex
 import { fetchExerciseTypeOptions } from '~/services/exerciseTypes.server';
 import { parseData } from '~/utils/validation';
 import { parseFormData } from '~/utils/upload.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const [exercise, exerciseTypes] = await Promise.all([
-    fetchExerciseById(params.id!, 'en'),
-    fetchExerciseTypeOptions('en', 'exercise-form'),
+    fetchExerciseById(params.id!, getDefaultLocale()),
+    fetchExerciseTypeOptions(getDefaultLocale(), 'exercise-form'),
   ]);
 
   if (!exercise) {
@@ -95,7 +96,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const newImage = typeof imageValue === 'string' && imageValue ? imageValue : null;
 
   // Fetch existing exercise to preserve image if not updated or removed
-  const existingExercise = await fetchExerciseById(params.id!, 'en');
+  const existingExercise = await fetchExerciseById(params.id!, getDefaultLocale());
 
   if (!existingExercise) {
     throw new Response('Exercise not found', { status: 404 });

--- a/app/routes/exercises.$slug.tsx
+++ b/app/routes/exercises.$slug.tsx
@@ -2,9 +2,10 @@ import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import ExerciseDetailPage from '~/pages/ExerciseDetailPage';
 import { fetchExerciseBySlug } from '~/services/exercises.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const exercise = await fetchExerciseBySlug(params.slug!, 'en');
+  const exercise = await fetchExerciseBySlug(params.slug!, getDefaultLocale());
 
   if (!exercise) {
     throw new Response('Exercise not found', { status: 404 });

--- a/app/routes/exercises._index.tsx
+++ b/app/routes/exercises._index.tsx
@@ -3,6 +3,7 @@ import { useLoaderData } from '@remix-run/react';
 import ExercisesListPage from '~/pages/ExercisesListPage';
 import { fetchExercises, type ExerciseFilters } from '~/services/exercises.server';
 import { fetchExerciseTypeOptions } from '~/services/exerciseTypes.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -16,8 +17,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   };
 
   const [exercises, exerciseTypes] = await Promise.all([
-    fetchExercises('en', filters),
-    fetchExerciseTypeOptions('en', 'exercise-form'),
+    fetchExercises(getDefaultLocale(), filters),
+    fetchExerciseTypeOptions(getDefaultLocale(), 'exercise-form'),
   ]);
 
   return json({ exercises, exerciseTypes, deleted });

--- a/app/routes/exercises.new.tsx
+++ b/app/routes/exercises.new.tsx
@@ -6,9 +6,10 @@ import { createExercise } from '~/services/exercises.server';
 import { fetchExerciseTypeOptions } from '~/services/exerciseTypes.server';
 import { parseData } from '~/utils/validation';
 import { parseFormData } from '~/utils/upload.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export async function loader() {
-  const exerciseTypes = await fetchExerciseTypeOptions('en', 'exercise-form');
+  const exerciseTypes = await fetchExerciseTypeOptions(getDefaultLocale(), 'exercise-form');
   return json({ exerciseTypes });
 }
 

--- a/app/routes/practise-sessions.$id_.edit.tsx
+++ b/app/routes/practise-sessions.$id_.edit.tsx
@@ -4,6 +4,7 @@ import { useLoaderData } from '@remix-run/react';
 import EditPractiseSessionPage from '~/pages/EditPractiseSessionPage';
 import { fetchPracticeSessionById } from '~/services/practiceSessions.server';
 import { fetchSectionsForPractiseSession } from '~/services/sections.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data?.session) {
@@ -14,8 +15,8 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const [session, sections] = await Promise.all([
-    fetchPracticeSessionById(params.id!, 'en'),
-    fetchSectionsForPractiseSession('en'),
+    fetchPracticeSessionById(params.id!, getDefaultLocale()),
+    fetchSectionsForPractiseSession(getDefaultLocale()),
   ]);
 
   if (!session) {

--- a/app/routes/practise-sessions.$slug.tsx
+++ b/app/routes/practise-sessions.$slug.tsx
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import PractiseSessionDetail from '~/pages/PractiseSessionDetail';
 import { fetchPracticeSessionBySlug } from '~/services/practiceSessions.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data?.session) {
@@ -12,7 +13,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 };
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const session = await fetchPracticeSessionBySlug(params.slug!, 'en');
+  const session = await fetchPracticeSessionBySlug(params.slug!, getDefaultLocale());
 
   if (!session) {
     throw new Response('Practice session not found', { status: 404 });

--- a/app/routes/practise-sessions.new.tsx
+++ b/app/routes/practise-sessions.new.tsx
@@ -5,13 +5,14 @@ import PractiseSessionForm from '~/pages/PractiseSessionForm';
 import { fetchSectionsForPractiseSession } from '~/services/sections.server';
 import { createPracticeSession } from '~/services/practiceSessions.server';
 import type { SelectedItem } from '~/types';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export const meta: MetaFunction = () => {
   return [{ title: 'Design Practice Session - Harkkapankki' }];
 };
 
 export async function loader() {
-  const sections = await fetchSectionsForPractiseSession('en');
+  const sections = await fetchSectionsForPractiseSession(getDefaultLocale());
   return json({ sections });
 }
 

--- a/app/services/exerciseTypes.server.ts
+++ b/app/services/exerciseTypes.server.ts
@@ -1,5 +1,6 @@
 import * as exerciseTypeRepo from '~/repositories/exerciseType.server';
 import type { ExerciseTypeOption } from '~/types';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 type ExerciseTypeWithPath = {
   id: string;
@@ -53,7 +54,7 @@ export async function fetchExerciseTypePath(
 }
 
 export async function fetchExerciseTypeOptions(
-  language: string = 'en',
+  language: string = getDefaultLocale(),
   groupSlug?: string
 ): Promise<ExerciseTypeOption[]> {
   const types = await exerciseTypeRepo.findRootExerciseTypesWithChildren(language, groupSlug);

--- a/app/services/exercises.server.ts
+++ b/app/services/exercises.server.ts
@@ -2,6 +2,7 @@ import type { Exercise } from '@prisma/client';
 import * as exerciseRepo from '~/repositories/exercise.server';
 import { fetchExerciseTypePath } from './exerciseTypes.server';
 import { slugify, makeUniqueSlug } from '~/utils/slugify';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export type ExerciseInput = {
   name: string;
@@ -23,7 +24,7 @@ export type ExerciseFilters = {
 };
 
 export async function fetchExercises(
-  language: string = 'en',
+  language: string = getDefaultLocale(),
   filters?: ExerciseFilters
 ): Promise<ExerciseWithTypePath[]> {
   const where: exerciseRepo.ExerciseWhereInput = {};
@@ -61,7 +62,7 @@ export async function fetchExercises(
 
 export async function fetchExerciseById(
   id: string,
-  language: string = 'en'
+  language: string = getDefaultLocale()
 ): Promise<ExerciseWithTypePath | null> {
   const exercise = await exerciseRepo.findExerciseById(id);
 
@@ -80,7 +81,7 @@ export async function fetchExerciseById(
 
 export async function fetchExerciseBySlug(
   slug: string,
-  language: string = 'en'
+  language: string = getDefaultLocale()
 ): Promise<ExerciseWithTypePath | null> {
   const exercise = await exerciseRepo.findExerciseBySlug(slug);
 

--- a/app/services/practiceSessions.server.ts
+++ b/app/services/practiceSessions.server.ts
@@ -1,6 +1,7 @@
 import * as practiceSessionRepo from '~/repositories/practiceSession.server';
 import type { SelectedItem } from '~/types';
 import { slugify, makeUniqueSlug } from '~/utils/slugify';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 type CreatePracticeSessionInput = {
   name?: string;
@@ -54,10 +55,10 @@ export async function fetchPracticeSessions() {
   return practiceSessionRepo.findAllPracticeSessions();
 }
 
-export async function fetchPracticeSessionById(id: string, language: string = 'en') {
+export async function fetchPracticeSessionById(id: string, language: string = getDefaultLocale()) {
   return practiceSessionRepo.findPracticeSessionById(id, language);
 }
 
-export async function fetchPracticeSessionBySlug(slug: string, language: string = 'en') {
+export async function fetchPracticeSessionBySlug(slug: string, language: string = getDefaultLocale()) {
   return practiceSessionRepo.findPracticeSessionBySlug(slug, language);
 }

--- a/app/services/sections.server.ts
+++ b/app/services/sections.server.ts
@@ -1,7 +1,8 @@
 import * as sectionRepo from '~/repositories/section.server';
 import type { Section, PractiseLength } from '~/types';
+import { getDefaultLocale } from '~/utils/locale.server';
 
-export async function fetchSectionsForPractiseSession(language: string = 'en'): Promise<Section[]> {
+export async function fetchSectionsForPractiseSession(language: string = getDefaultLocale()): Promise<Section[]> {
   const dbSections = await sectionRepo.findAllSectionsWithDetails(language);
 
   return dbSections.map(section => {

--- a/app/utils/locale.server.ts
+++ b/app/utils/locale.server.ts
@@ -1,0 +1,3 @@
+export function getDefaultLocale(): string {
+  return process.env.APP_LOCALE || 'en';
+}


### PR DESCRIPTION
…types

- Add APP_LOCALE environment variable to configure default application language
- Create locale.server.ts utility to read locale from environment (defaults to 'en')
- Update all service and route files to use getDefaultLocale() instead of hardcoded 'en'
- Implement deterministic UUID v5 generation for exercise types in seed script
- Exercise types now maintain consistent UUIDs across database reseeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)