### PR TITLE
Add exercise-level selection to practice session form

### DIFF
--- a/.claude/skills/typescript/LICENSE.txt
+++ b/.claude/skills/typescript/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: typescript
+description: Expert in TypeScript development with best practices for type safety and clean code. Use when writing, reviewing, or refactoring TypeScript code.
+user-invocable: false
+---
+
+You are an expert in TypeScript development with deep knowledge of type safety and modern JavaScript patterns.
+
+## Core Principles
+
+### Code Style & Structure
+
+- Write concise, technical TypeScript with accurate examples
+- Use functional and declarative programming patterns; avoid classes
+- Prefer iteration and modularization over code duplication
+- Use descriptive variable names with auxiliary verbs (e.g., isLoading, hasError)
+- Structure files: exported component, subcomponents, helpers, static content, types
+
+### Naming Conventions
+
+- Use PascalCase for classes, types, and interfaces
+- Use camelCase for variables, functions, and methods
+- Use kebab-case for file and directory names
+- Use UPPERCASE for environment variables and constants
+- Prefix functions with verbs; use boolean prefixes like is, has, can
+
+### TypeScript Usage
+
+- Use TypeScript for all code; prefer types over interfaces
+- Avoid any type; create precise type definitions
+- Use functional components with TypeScript types
+- Avoid enums; use maps instead
+- Use readonly for immutable properties
+- Use as const for literal values
+
+### Functions & Methods
+
+- Write short functions with single purpose (less than 20 lines)
+- Use arrow functions for simple operations (less than 3 lines)
+- Use named functions for complex logic
+- Implement early returns to avoid nested blocks
+- Use default parameters instead of null/undefined checks
+- Apply the RORO pattern: "Receive an Object, Return an Object"
+
+### Data & Classes
+
+- Encapsulate data in composite types
+- Prefer immutability where possible
+- Follow SOLID principles
+- Prefer composition over inheritance
+- Keep classes under 200 lines with fewer than 10 public methods
+
+### Error Handling
+
+- Use exceptions for unexpected errors
+- Implement proper error logging with context
+- Create custom error types for consistency
+- Use guard clauses for preconditions
+- Catch exceptions only to fix expected problems or add context
+
+### Documentation
+
+- Use JSDoc for public classes and methods
+- Document all exports clearly
+- Provide usage examples when appropriate
+- Keep documentation concise and accurate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,6 @@
   - run `npm run format`
     Code conventions
 
-- prefer types to interfaces
 - use native Javascript functions when possible
 - use Date.toLocaleDateString() instead of a custom made date formatting function
 - follow same naming conventions (files, functions etc) as is previously used in the project

--- a/app/components/PractiseSessionSection.tsx
+++ b/app/components/PractiseSessionSection.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
-import type { Section, SectionItem, PractiseLength } from '~/types';
+import type { Section, PractiseLength, SelectedItem } from '~/types';
+import { useTranslation } from 'react-i18next';
 
 type PractiseSessionSectionProps = {
   section: Section;
   practiseLength: PractiseLength;
-  selectedItems: SectionItem[];
-  onAddItem: (item: SectionItem) => void;
-  onRemoveItem: (itemValue: string) => void;
+  selectedItems: SelectedItem[];
+  onAddItem: (item: SelectedItem) => void;
+  onRemoveItem: (itemValue: string, exerciseId?: string) => void;
 };
 
 export function PractiseSessionSection({
@@ -16,25 +17,80 @@ export function PractiseSessionSection({
   onAddItem,
   onRemoveItem,
 }: PractiseSessionSectionProps) {
-  const [selectedValue, setSelectedValue] = useState<string>('');
+  const { t } = useTranslation();
+  const [selectedTypeValue, setSelectedTypeValue] = useState<string>('');
+  const [selectedExerciseId, setSelectedExerciseId] = useState<string>('');
 
   // Get section duration based on practise length
   const duration =
     typeof section.duration === 'number' ? section.duration : section.duration[practiseLength];
 
-  // Get available items (exclude already selected)
-  const availableItems = section.items.filter(
-    item => !selectedItems.some(selected => selected.value === item.value)
-  );
+  // Find the currently selected exercise type
+  const selectedType = section.items.find(i => i.value === selectedTypeValue);
+  const hasExercises = selectedType?.exercises && selectedType.exercises.length > 0;
+
+  // Get available exercise types (exclude already selected for types without exercises)
+  const availableTypes = section.items.filter(item => {
+    if (item.exercises && item.exercises.length > 0) {
+      // Types with exercises: always show if there are unselected exercises
+      const selectedExerciseIds = selectedItems
+        .filter(sel => sel.itemValue === item.value && sel.exerciseId)
+        .map(sel => sel.exerciseId);
+      return item.exercises.some(ex => !selectedExerciseIds.includes(ex.value));
+    }
+    // Types without exercises: hide if already selected
+    return !selectedItems.some(sel => sel.itemValue === item.value);
+  });
+
+  // Get available exercises for selected type (exclude already selected)
+  const availableExercises = hasExercises
+    ? selectedType.exercises!.filter(ex => !selectedItems.some(sel => sel.exerciseId === ex.value))
+    : [];
+
+  const handleTypeChange = (value: string) => {
+    setSelectedTypeValue(value);
+    setSelectedExerciseId('');
+  };
 
   const handleAdd = () => {
-    if (!selectedValue) return;
+    if (!selectedTypeValue) return;
 
-    const item = section.items.find(i => i.value === selectedValue);
-    if (item) {
-      onAddItem(item);
-      setSelectedValue('');
+    if (hasExercises) {
+      if (!selectedExerciseId) return;
+      const exercise = selectedType!.exercises!.find(e => e.value === selectedExerciseId);
+      if (exercise) {
+        onAddItem({
+          sectionId: section.id,
+          itemValue: selectedTypeValue,
+          exerciseId: exercise.value,
+          exerciseLabel: exercise.label,
+        });
+        setSelectedExerciseId('');
+        // Check if there are remaining exercises for this type
+        const remainingAfterAdd = availableExercises.filter(ex => ex.value !== selectedExerciseId);
+        if (remainingAfterAdd.length === 0) {
+          setSelectedTypeValue('');
+        }
+      }
+    } else {
+      onAddItem({
+        sectionId: section.id,
+        itemValue: selectedTypeValue,
+      });
+      setSelectedTypeValue('');
     }
+  };
+
+  const canAdd = hasExercises ? !!selectedExerciseId : !!selectedTypeValue;
+
+  // Build display label for selected items
+  const getItemLabel = (item: SelectedItem): string => {
+    const type = section.items.find(i => i.value === item.itemValue);
+    const typeName = type?.label || item.itemValue;
+    if (item.exerciseLabel) {
+      return `${typeName}: ${item.exerciseLabel}`;
+    }
+    return typeName;
   };
 
   return (
@@ -47,46 +103,69 @@ export function PractiseSessionSection({
       </div>
 
       {/* Item selector */}
-      <div className="mb-3 flex gap-2">
+      <div className="mb-3 flex flex-wrap gap-2">
         <select
-          value={selectedValue}
-          onChange={e => setSelectedValue(e.target.value)}
-          className="flex-1 rounded-md border border-gray-300 px-3 py-2"
-          disabled={availableItems.length === 0}
+          value={selectedTypeValue}
+          onChange={e => handleTypeChange(e.target.value)}
+          className="flex-1 min-w-0 rounded-md border border-gray-300 px-3 py-2"
+          disabled={availableTypes.length === 0}
         >
           <option value="">
-            {availableItems.length === 0 ? 'No items available' : 'Select item...'}
+            {availableTypes.length === 0
+              ? t('sections.noItemsAvailable', 'No items available')
+              : t('sections.selectItem', 'Select item...')}
           </option>
-          {availableItems.map(item => (
+          {availableTypes.map(item => (
             <option key={item.value} value={item.value}>
               {item.label}
             </option>
           ))}
         </select>
+
+        {hasExercises && (
+          <select
+            value={selectedExerciseId}
+            onChange={e => setSelectedExerciseId(e.target.value)}
+            className="flex-1 min-w-0 rounded-md border border-gray-300 px-3 py-2"
+            disabled={availableExercises.length === 0}
+          >
+            <option value="">
+              {availableExercises.length === 0
+                ? t('sections.noExercisesAvailable', 'No exercises available')
+                : t('sections.selectExercise', 'Select exercise...')}
+            </option>
+            {availableExercises.map(ex => (
+              <option key={ex.value} value={ex.value}>
+                {ex.label}
+              </option>
+            ))}
+          </select>
+        )}
+
         <button
           type="button"
           onClick={handleAdd}
-          disabled={!selectedValue}
+          disabled={!canAdd}
           className="rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
         >
-          Add
+          {t('common.add', 'Add')}
         </button>
       </div>
 
       {/* Selected items list */}
       {selectedItems.length > 0 && (
         <ul className="space-y-2">
-          {selectedItems.map(item => (
+          {selectedItems.map((item, index) => (
             <li
-              key={item.value}
+              key={`${item.itemValue}-${item.exerciseId || index}`}
               className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2"
             >
-              <span className="text-gray-700">• {item.label}</span>
+              <span className="text-gray-700">• {getItemLabel(item)}</span>
               <button
                 type="button"
-                onClick={() => onRemoveItem(item.value)}
+                onClick={() => onRemoveItem(item.itemValue, item.exerciseId)}
                 className="text-red-600 hover:text-red-800 font-bold"
-                aria-label={`Remove ${item.label}`}
+                aria-label={`Remove ${getItemLabel(item)}`}
               >
                 ×
               </button>
@@ -96,7 +175,9 @@ export function PractiseSessionSection({
       )}
 
       {selectedItems.length === 0 && (
-        <p className="text-sm text-gray-500 italic">No items selected</p>
+        <p className="text-sm text-gray-500 italic">
+          {t('sections.noItemsSelected', 'No items selected')}
+        </p>
       )}
     </div>
   );

--- a/app/pages/EditPractiseSessionPage.tsx
+++ b/app/pages/EditPractiseSessionPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Form } from '@remix-run/react';
-import type { PractiseLength, SelectedItem, Section, SectionItem } from '~/types';
+import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
 import { PractiseSessionSummary } from '~/components/PractiseSessionSummary';
@@ -19,7 +19,12 @@ type PracticeSessionData = {
     };
     exerciseType: {
       id: string;
+      translations: Array<{ name: string }>;
     };
+    exercise?: {
+      id: string;
+      name: string;
+    } | null;
   }>;
 };
 
@@ -33,10 +38,14 @@ export default function EditPractiseSessionPage({
   sections,
 }: EditPractiseSessionPageProps) {
   const { t } = useTranslation();
-  // Initialize with existing session data
+  // Initialize with existing session data, including exercise info if present
   const initialSelectedItems: SelectedItem[] = session.sectionItems.map(item => ({
     sectionId: item.section.id,
     itemValue: item.exerciseType.id,
+    ...(item.exercise && {
+      exerciseId: item.exercise.id,
+      exerciseLabel: item.exercise.name,
+    }),
   }));
 
   const [practiseLength, setPractiseLength] = useState<PractiseLength>(
@@ -64,28 +73,24 @@ export default function EditPractiseSessionPage({
   };
 
   // Get selected items for a specific section
-  const getSectionItems = (sectionId: string): SectionItem[] => {
-    const section = sections.find(s => s.id === sectionId);
-    if (!section) return [];
-
-    return selectedItems
-      .filter(item => item.sectionId === sectionId)
-      .map(item => {
-        const sectionItem = section.items.find(i => i.value === item.itemValue);
-        return sectionItem!;
-      })
-      .filter(Boolean);
+  const getSectionSelectedItems = (sectionId: string): SelectedItem[] => {
+    return selectedItems.filter(item => item.sectionId === sectionId);
   };
 
   // Add item to section
-  const handleAddItem = (sectionId: string, item: SectionItem) => {
-    setSelectedItems(prev => [...prev, { sectionId, itemValue: item.value }]);
+  const handleAddItem = (item: SelectedItem) => {
+    setSelectedItems(prev => [...prev, item]);
   };
 
   // Remove item from section
-  const handleRemoveItem = (sectionId: string, itemValue: string) => {
+  const handleRemoveItem = (sectionId: string, itemValue: string, exerciseId?: string) => {
     setSelectedItems(prev =>
-      prev.filter(item => !(item.sectionId === sectionId && item.itemValue === itemValue))
+      prev.filter(item => {
+        if (item.sectionId !== sectionId) return true;
+        if (item.itemValue !== itemValue) return true;
+        if (exerciseId) return item.exerciseId !== exerciseId;
+        return false;
+      })
     );
   };
 
@@ -184,9 +189,11 @@ export default function EditPractiseSessionPage({
                 key={section.id}
                 section={section}
                 practiseLength={practiseLength}
-                selectedItems={getSectionItems(section.id)}
-                onAddItem={item => handleAddItem(section.id, item)}
-                onRemoveItem={itemValue => handleRemoveItem(section.id, itemValue)}
+                selectedItems={getSectionSelectedItems(section.id)}
+                onAddItem={handleAddItem}
+                onRemoveItem={(itemValue, exerciseId) =>
+                  handleRemoveItem(section.id, itemValue, exerciseId)
+                }
               />
             ))}
           </div>

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -17,6 +17,11 @@ type SectionItem = {
       name: string;
     }>;
   };
+  exercise?: {
+    id: string;
+    name: string;
+    slug: string;
+  } | null;
 };
 
 type PracticeSessionData = {
@@ -136,7 +141,9 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
                       {item.order}
                     </span>
                     <span className="text-gray-700">
-                      {item.exerciseType.translations[0]?.name || item.exerciseType.id}
+                      {item.exercise
+                        ? `${item.exerciseType.translations[0]?.name || item.exerciseType.id}: ${item.exercise.name}`
+                        : item.exerciseType.translations[0]?.name || item.exerciseType.id}
                     </span>
                   </li>
                 ))}

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -135,18 +135,93 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
                 {section.translations[0]?.name || section.slug}
               </h3>
               <ul className="space-y-2">
-                {items.map(item => (
-                  <li key={item.id} className="flex items-start p-3 bg-gray-50 rounded-md">
-                    <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
-                      {item.order}
-                    </span>
-                    <span className="text-gray-700">
-                      {item.exercise
-                        ? `${item.exerciseType.translations[0]?.name || item.exerciseType.id}: ${item.exercise.name}`
-                        : item.exerciseType.translations[0]?.name || item.exerciseType.id}
-                    </span>
-                  </li>
-                ))}
+                {(() => {
+                  // Group items by exercise type
+                  const groupedByType: Array<{
+                    typeName: string;
+                    items: SectionItem[];
+                  }> = [];
+                  for (const item of items) {
+                    const typeName =
+                      item.exerciseType.translations[0]?.name || item.exerciseType.id;
+                    const existing = groupedByType.find(g => g.typeName === typeName);
+                    if (existing) {
+                      existing.items.push(item);
+                    } else {
+                      groupedByType.push({ typeName, items: [item] });
+                    }
+                  }
+
+                  return groupedByType.map(group => {
+                    const exercisesInGroup = group.items.filter(i => i.exercise);
+
+                    // No exercises linked - show type name only
+                    if (exercisesInGroup.length === 0) {
+                      return group.items.map(item => (
+                        <li
+                          key={item.id}
+                          className="flex items-start p-3 bg-gray-50 rounded-md"
+                        >
+                          <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
+                            {item.order}
+                          </span>
+                          <span className="text-gray-700">{group.typeName}</span>
+                        </li>
+                      ));
+                    }
+
+                    // Single exercise with same name as type - show once
+                    if (
+                      exercisesInGroup.length === 1 &&
+                      exercisesInGroup[0].exercise!.name === group.typeName
+                    ) {
+                      return (
+                        <li
+                          key={exercisesInGroup[0].id}
+                          className="flex items-start p-3 bg-gray-50 rounded-md"
+                        >
+                          <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
+                            {exercisesInGroup[0].order}
+                          </span>
+                          <Link
+                            to={`/exercises/${exercisesInGroup[0].exercise!.slug}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:text-blue-800 hover:underline"
+                          >
+                            {group.typeName}
+                          </Link>
+                        </li>
+                      );
+                    }
+
+                    // Multiple exercises or single with different name - group under type
+                    return (
+                      <li key={group.typeName} className="p-3 bg-gray-50 rounded-md">
+                        <div className="font-medium text-gray-700 mb-2">
+                          {group.typeName}
+                        </div>
+                        <ul className="ml-4 space-y-1">
+                          {exercisesInGroup.map(item => (
+                            <li key={item.id} className="flex items-start">
+                              <span className="flex-shrink-0 w-5 h-5 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-xs font-medium mr-2">
+                                {item.order}
+                              </span>
+                              <Link
+                                to={`/exercises/${item.exercise!.slug}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:text-blue-800 hover:underline"
+                              >
+                                {item.exercise!.name}
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
+                      </li>
+                    );
+                  });
+                })()}
               </ul>
             </div>
           ))

--- a/app/pages/PractiseSessionForm.tsx
+++ b/app/pages/PractiseSessionForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Form } from '@remix-run/react';
-import type { PractiseLength, SelectedItem, Section, SectionItem } from '~/types';
+import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
 import { PractiseSessionSummary } from '~/components/PractiseSessionSummary';
@@ -34,28 +34,24 @@ export default function PractiseSessionForm({ sections }: PractiseSessionFormPro
   };
 
   // Get selected items for a specific section
-  const getSectionItems = (sectionId: string): SectionItem[] => {
-    const section = sections.find(s => s.id === sectionId);
-    if (!section) return [];
-
-    return selectedItems
-      .filter(item => item.sectionId === sectionId)
-      .map(item => {
-        const sectionItem = section.items.find(i => i.value === item.itemValue);
-        return sectionItem!;
-      })
-      .filter(Boolean);
+  const getSectionSelectedItems = (sectionId: string): SelectedItem[] => {
+    return selectedItems.filter(item => item.sectionId === sectionId);
   };
 
   // Add item to section
-  const handleAddItem = (sectionId: string, item: SectionItem) => {
-    setSelectedItems(prev => [...prev, { sectionId, itemValue: item.value }]);
+  const handleAddItem = (item: SelectedItem) => {
+    setSelectedItems(prev => [...prev, item]);
   };
 
   // Remove item from section
-  const handleRemoveItem = (sectionId: string, itemValue: string) => {
+  const handleRemoveItem = (sectionId: string, itemValue: string, exerciseId?: string) => {
     setSelectedItems(prev =>
-      prev.filter(item => !(item.sectionId === sectionId && item.itemValue === itemValue))
+      prev.filter(item => {
+        if (item.sectionId !== sectionId) return true;
+        if (item.itemValue !== itemValue) return true;
+        if (exerciseId) return item.exerciseId !== exerciseId;
+        return false;
+      })
     );
   };
 
@@ -139,9 +135,11 @@ export default function PractiseSessionForm({ sections }: PractiseSessionFormPro
                 key={section.id}
                 section={section}
                 practiseLength={practiseLength}
-                selectedItems={getSectionItems(section.id)}
-                onAddItem={item => handleAddItem(section.id, item)}
-                onRemoveItem={itemValue => handleRemoveItem(section.id, itemValue)}
+                selectedItems={getSectionSelectedItems(section.id)}
+                onAddItem={handleAddItem}
+                onRemoveItem={(itemValue, exerciseId) =>
+                  handleRemoveItem(section.id, itemValue, exerciseId)
+                }
               />
             ))}
           </div>

--- a/app/repositories/practiceSession.server.ts
+++ b/app/repositories/practiceSession.server.ts
@@ -8,6 +8,7 @@ type CreatePracticeSessionData = {
   sectionItems: Array<{
     sectionId: string;
     exerciseTypeId: string;
+    exerciseId?: string | null;
     order: number;
   }>;
 };
@@ -78,6 +79,9 @@ export async function findPracticeSessionById(id: string, language: string) {
               },
             },
           },
+          exercise: {
+            select: { id: true, name: true, slug: true },
+          },
         },
       },
     },
@@ -105,6 +109,9 @@ export async function findPracticeSessionBySlug(slug: string, language: string) 
               },
             },
           },
+          exercise: {
+            select: { id: true, name: true, slug: true },
+          },
         },
       },
     },
@@ -118,6 +125,7 @@ type UpdatePracticeSessionData = {
   sectionItems: Array<{
     sectionId: string;
     exerciseTypeId: string;
+    exerciseId?: string | null;
     order: number;
   }>;
 };

--- a/app/repositories/section.server.ts
+++ b/app/repositories/section.server.ts
@@ -7,7 +7,11 @@ export type SectionWithDetails = {
   name: string;
   description: string | null;
   durationConfigs: { sessionLength: number; duration: number }[];
-  exerciseTypes: { id: string; name: string }[];
+  exerciseTypes: {
+    id: string;
+    name: string;
+    exercises: { id: string; name: string }[];
+  }[];
 };
 
 export async function findAllSectionsWithDetails(
@@ -32,6 +36,10 @@ export async function findAllSectionsWithDetails(
                 where: { language },
                 select: { name: true },
               },
+              exercises: {
+                select: { id: true, name: true },
+                orderBy: { name: 'asc' },
+              },
             },
           },
         },
@@ -49,6 +57,10 @@ export async function findAllSectionsWithDetails(
     exerciseTypes: section.exerciseTypeLinks.map(link => ({
       id: link.exerciseType.id,
       name: link.exerciseType.translations[0]?.name || link.exerciseType.slug,
+      exercises: link.exerciseType.exercises.map(ex => ({
+        id: ex.id,
+        name: ex.name,
+      })),
     })),
   }));
 }

--- a/app/services/practiceSessions.server.ts
+++ b/app/services/practiceSessions.server.ts
@@ -38,6 +38,7 @@ export async function createPracticeSession(input: CreatePracticeSessionInput) {
     items.map((item, index) => ({
       sectionId,
       exerciseTypeId: item.itemValue,
+      exerciseId: item.exerciseId || null,
       order: index + 1,
     }))
   );
@@ -75,6 +76,7 @@ export async function updatePracticeSession(input: UpdatePracticeSessionInput) {
     items.map((item, index) => ({
       sectionId,
       exerciseTypeId: item.itemValue,
+      exerciseId: item.exerciseId || null,
       order: index + 1,
     }))
   );

--- a/app/services/sections.server.ts
+++ b/app/services/sections.server.ts
@@ -45,6 +45,9 @@ export async function fetchSectionsForPractiseSession(
       items: section.exerciseTypes.map(type => ({
         value: type.id,
         label: type.name,
+        ...(type.exercises.length > 0 && {
+          exercises: type.exercises.map(ex => ({ value: ex.id, label: ex.name })),
+        }),
       })),
     };
   });

--- a/app/types.ts
+++ b/app/types.ts
@@ -8,9 +8,15 @@ export type ExerciseTypeOption = {
 // Practice Session Types
 export type PractiseLength = 60 | 90;
 
+export type ExerciseOption = {
+  value: string; // exercise ID
+  label: string; // exercise name
+};
+
 export type SectionItem = {
-  value: string; // UUID
+  value: string; // UUID (exerciseTypeId)
   label: string; // Human readable
+  exercises?: ExerciseOption[];
 };
 
 export type Section = {
@@ -22,5 +28,7 @@ export type Section = {
 
 export type SelectedItem = {
   sectionId: string;
-  itemValue: string;
+  itemValue: string; // exerciseTypeId
+  exerciseId?: string;
+  exerciseLabel?: string;
 };

--- a/prisma/migrations/20260401140208_add_exercise_to_session_item/migration.sql
+++ b/prisma/migrations/20260401140208_add_exercise_to_session_item/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[practice_session_id,section_id,exercise_type_id,exercise_id]` on the table `practice_session_section_items` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "practice_session_section_items_practice_session_id_section__key";
+
+-- AlterTable
+ALTER TABLE "practice_session_section_items" ADD COLUMN     "exercise_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "practice_session_section_items_exercise_id_idx" ON "practice_session_section_items"("exercise_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "practice_session_section_items_practice_session_id_section__key" ON "practice_session_section_items"("practice_session_id", "section_id", "exercise_type_id", "exercise_id");
+
+-- AddForeignKey
+ALTER TABLE "practice_session_section_items" ADD CONSTRAINT "practice_session_section_items_exercise_id_fkey" FOREIGN KEY ("exercise_id") REFERENCES "exercises"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,8 @@ model Exercise {
   createdAt     DateTime    @default(now()) @map("created_at")
   updatedAt     DateTime    @updatedAt @map("updated_at")
 
+  sessionItems  PracticeSessionSectionItem[]
+
   @@map("exercises")
   @@index([exerciseTypeId])
 }
@@ -182,13 +184,16 @@ model PracticeSessionSectionItem {
   sectionId         String          @map("section_id")
   exerciseType      ExerciseType    @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
   exerciseTypeId    String          @map("exercise_type_id")
+  exercise          Exercise?       @relation(fields: [exerciseId], references: [id], onDelete: SetNull)
+  exerciseId        String?         @map("exercise_id")
   order             Int
   createdAt         DateTime        @default(now()) @map("created_at")
   updatedAt         DateTime        @updatedAt @map("updated_at")
 
   @@map("practice_session_section_items")
-  @@unique([practiceSessionId, sectionId, exerciseTypeId])
+  @@unique([practiceSessionId, sectionId, exerciseTypeId, exerciseId])
   @@index([practiceSessionId])
   @@index([sectionId])
   @@index([exerciseTypeId])
+  @@index([exerciseId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -40,7 +40,10 @@ const exerciseTypes: ExerciseTypeData[] = [
     slug: 'supplementary',
     translations: { fi: 'Oheisharjoitteet', en: 'Supplementary exercises' },
   },
-  { slug: 'games', translations: { fi: 'Pelit, leikit ja haasteet', en: 'Games, plays and challenges' } },
+  {
+    slug: 'games',
+    translations: { fi: 'Pelit, leikit ja haasteet', en: 'Games, plays and challenges' },
+  },
 
   // Technique subcategories
   {
@@ -234,6 +237,9 @@ async function seed() {
       'muscle-condition',
       'putting',
       'driving',
+      'throwing-games',
+      'warm-up-games',
+      'putting-games',
       'closing',
     ];
     for (const slug of sessionFormTypes) {
@@ -253,11 +259,14 @@ async function seed() {
     const warmUpSection = await db.section.create({
       data: { slug: 'warm-up', order: 2 },
     });
+    const gamesSection = await db.section.create({
+      data: { slug: 'games', order: 3 },
+    });
     const techniqueSection = await db.section.create({
-      data: { slug: 'technique', order: 3 },
+      data: { slug: 'technique', order: 4 },
     });
     const closingSection = await db.section.create({
-      data: { slug: 'closing', order: 4 },
+      data: { slug: 'closing', order: 5 },
     });
 
     // Create section translations
@@ -267,6 +276,8 @@ async function seed() {
         { sectionId: introSection.id, language: 'en', name: 'Introduction' },
         { sectionId: warmUpSection.id, language: 'fi', name: 'Alkulämmittely' },
         { sectionId: warmUpSection.id, language: 'en', name: 'Warm-up' },
+        { sectionId: gamesSection.id, language: 'fi', name: 'Pelit, leikit ja haasteet' },
+        { sectionId: gamesSection.id, language: 'en', name: 'Games, plays and challenges' },
         { sectionId: techniqueSection.id, language: 'fi', name: 'Tekniikka' },
         { sectionId: techniqueSection.id, language: 'en', name: 'Technique' },
         { sectionId: closingSection.id, language: 'fi', name: 'Lopetus' },
@@ -284,9 +295,12 @@ async function seed() {
         // Warm-up - 10 min for 60, 20 min for 90
         { sectionId: warmUpSection.id, sessionLength: 60, duration: 10 },
         { sectionId: warmUpSection.id, sessionLength: 90, duration: 20 },
-        // Technique - 40 min for 60, 60 min for 90
-        { sectionId: techniqueSection.id, sessionLength: 60, duration: 40 },
-        { sectionId: techniqueSection.id, sessionLength: 90, duration: 60 },
+        // Games - 5 min for 60, 10 min for 90
+        { sectionId: gamesSection.id, sessionLength: 60, duration: 5 },
+        { sectionId: gamesSection.id, sessionLength: 90, duration: 10 },
+        // Technique - 35 min for 60, 50 min for 90
+        { sectionId: techniqueSection.id, sessionLength: 60, duration: 35 },
+        { sectionId: techniqueSection.id, sessionLength: 90, duration: 50 },
         // Closing - 5 min for both
         { sectionId: closingSection.id, sessionLength: 60, duration: 5 },
         { sectionId: closingSection.id, sessionLength: 90, duration: 5 },
@@ -304,6 +318,10 @@ async function seed() {
         { sectionId: warmUpSection.id, exerciseTypeId: slugToId['motor-skills'] },
         { sectionId: warmUpSection.id, exerciseTypeId: slugToId['muscle-condition'] },
         { sectionId: warmUpSection.id, exerciseTypeId: slugToId['strength'] },
+        // Games section
+        { sectionId: gamesSection.id, exerciseTypeId: slugToId['throwing-games'] },
+        { sectionId: gamesSection.id, exerciseTypeId: slugToId['warm-up-games'] },
+        { sectionId: gamesSection.id, exerciseTypeId: slugToId['putting-games'] },
         // Technique section
         { sectionId: techniqueSection.id, exerciseTypeId: slugToId['putting'] },
         { sectionId: techniqueSection.id, exerciseTypeId: slugToId['driving'] },


### PR DESCRIPTION
## Summary
- Add new "Pelit, leikit ja haasteet" (Games) section with sub-categories: Heittopelit, Lämmittelypelit, Puttipelit
- Two-level picker in the form: select exercise type, then select specific exercise from that type
- Add optional `exerciseId` to `PracticeSessionSectionItem` schema for storing selected exercises
- View page shows "TypeName: ExerciseName" when a specific exercise is linked
- Games section: 5min (60-min session) / 10min (90-min session), Technique reduced to 35/50min
- Section order: Introduction → Warm-up → Games → Technique → Closing
- Existing sections and practice sessions continue to work unchanged

## Test plan
- [ ] Create a new practice session and verify the Games section appears with sub-categories
- [ ] Select a specific exercise from Puttipelit (second dropdown should show 13 putting games)
- [ ] Save the session and verify the exercise name displays on the view page
- [ ] Edit the session and verify exercise selections are preserved
- [ ] Verify existing practice sessions still display correctly
- [ ] Verify other sections (Introduction, Warm-up, Technique, Closing) still work with single dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)