### PR TITLE
Fix practise session deletion

### DIFF
--- a/app/pages/EditPractiseSessionPage.tsx
+++ b/app/pages/EditPractiseSessionPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Form } from 'react-router';
+import { Form, useSubmit } from 'react-router';
 import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
@@ -38,6 +38,7 @@ export default function EditPractiseSessionPage({
   sections,
 }: EditPractiseSessionPageProps) {
   const { t } = useTranslation();
+  const submit = useSubmit();
   // Initialize with existing session data, including exercise info if present
   const initialSelectedItems: SelectedItem[] = session.sectionItems.map(item => ({
     sectionId: item.section.id,
@@ -122,9 +123,8 @@ export default function EditPractiseSessionPage({
   };
 
   const handleDeleteConfirm = () => {
-    // TODO: Implement delete functionality
-    console.log('Delete confirmed');
     setShowDeleteDialog(false);
+    submit({ intent: 'delete' }, { method: 'post' });
   };
 
   const handleDeleteCancel = () => {

--- a/app/repositories/practiceSession.server.ts
+++ b/app/repositories/practiceSession.server.ts
@@ -166,6 +166,12 @@ export async function updatePracticeSession(id: string, data: UpdatePracticeSess
   });
 }
 
+export async function deletePracticeSession(id: string) {
+  return db.practiceSession.delete({
+    where: { id },
+  });
+}
+
 export async function findPracticeSessionsBySlugs(slugs: string[]) {
   return db.practiceSession.findMany({
     where: {

--- a/app/routes/practise-sessions.$id_.edit.tsx
+++ b/app/routes/practise-sessions.$id_.edit.tsx
@@ -1,5 +1,7 @@
 import {
+  data,
   redirect,
+  redirectDocument,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -7,6 +9,7 @@ import {
 import { useLoaderData } from 'react-router';
 import EditPractiseSessionPage from '~/pages/EditPractiseSessionPage';
 import {
+  deletePracticeSession,
   fetchPracticeSessionById,
   updatePracticeSession,
 } from '~/services/practiceSessions.server';
@@ -23,6 +26,23 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export async function action({ request, params }: ActionFunctionArgs) {
   const formData = await request.formData();
+  const intent = formData.get('intent');
+
+  if (intent === 'delete') {
+    try {
+      await deletePracticeSession(params.id!);
+      return redirectDocument('/practise-sessions?deleted=true');
+    } catch (error) {
+      return data(
+        {
+          success: false,
+          message: 'Failed to delete practice session. Please try again.',
+        },
+        { status: 500 }
+      );
+    }
+  }
+
   const name = formData.get('name') as string;
   const description = formData.get('description') as string;
   const sessionLength = parseInt(formData.get('sessionLength') as string, 10);

--- a/app/services/practiceSessions.server.ts
+++ b/app/services/practiceSessions.server.ts
@@ -89,6 +89,10 @@ export async function updatePracticeSession(input: UpdatePracticeSessionInput) {
   });
 }
 
+export async function deletePracticeSession(id: string) {
+  return practiceSessionRepo.deletePracticeSession(id);
+}
+
 export async function fetchPracticeSessions() {
   return practiceSessionRepo.findAllPracticeSessions();
 }


### PR DESCRIPTION
## Summary
- Implement the missing delete functionality for practise sessions
- Add `deletePracticeSession` to the repository and service layers
- Handle `intent=delete` in the route action, redirecting to the listing page after deletion
- Replace the TODO placeholder in the UI with a `useSubmit` call that posts the delete intent

## Test plan
- [ ] Navigate to a practise session edit page
- [ ] Click the delete button and confirm the deletion dialog
- [ ] Verify the session is deleted and you are redirected to `/practise-sessions?deleted=true`
- [ ] Verify that cancelling the dialog does not delete anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)