### PR TITLE
Use StyleX tokens and Button component throughout app

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 
-type ButtonVariant = 'primary' | 'secondary' | 'danger';
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'icon';
 
 type ButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'style'> & {
   variant?: ButtonVariant;
@@ -79,6 +79,29 @@ const styles = stylex.create({
     outlineColor: {
       default: 'transparent',
       ':focus-visible': '#ef4444',
+    },
+  },
+  ghost: {
+    backgroundColor: 'transparent',
+    color: {
+      default: '#2563eb',
+      ':hover': '#1e40af',
+    },
+    paddingBlock: 0,
+    paddingInline: 0,
+    outlineColor: {
+      default: 'transparent',
+      ':focus-visible': '#3b82f6',
+    },
+  },
+  icon: {
+    backgroundColor: 'transparent',
+    paddingBlock: 4,
+    paddingInline: 4,
+    borderRadius: 4,
+    outlineColor: {
+      default: 'transparent',
+      ':focus-visible': '#3b82f6',
     },
   },
 });

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -1,4 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
+import { color } from '~/styles/tokens.stylex';
+import { borderRadius, fontSize, fontWeight, spacing } from '~/styles/constants.stylex';
 
 type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'icon';
 
@@ -17,11 +19,11 @@ export function Button({ variant = 'primary', style, children, ...rest }: Button
 
 const styles = stylex.create({
   base: {
-    borderRadius: 6,
-    fontSize: 14,
-    fontWeight: 600,
-    paddingBlock: 8,
-    paddingInline: 16,
+    borderRadius: borderRadius.md,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.semibold,
+    paddingBlock: spacing.sm,
+    paddingInline: spacing.md,
     cursor: {
       default: 'pointer',
       ':disabled': 'not-allowed',
@@ -47,61 +49,61 @@ const styles = stylex.create({
   },
   primary: {
     backgroundColor: {
-      default: '#2563eb',
-      ':hover': '#1d4ed8',
+      default: color.buttonPrimaryBg,
+      ':hover': color.buttonPrimaryBgHover,
     },
-    color: '#ffffff',
+    color: color.buttonPrimaryColor,
     outlineColor: {
       default: 'transparent',
-      ':focus-visible': '#3b82f6',
+      ':focus-visible': color.buttonPrimaryOutline,
     },
   },
   secondary: {
     backgroundColor: {
-      default: '#ffffff',
-      ':hover': '#f9fafb',
+      default: color.buttonSecondaryBg,
+      ':hover': color.buttonSecondaryBgHover,
     },
-    color: '#374151',
+    color: color.buttonSecondaryColor,
     borderWidth: 1,
     borderStyle: 'solid',
-    borderColor: '#d1d5db',
+    borderColor: color.buttonSecondaryBorder,
     outlineColor: {
       default: 'transparent',
-      ':focus-visible': '#3b82f6',
+      ':focus-visible': color.buttonSecondaryOutline,
     },
   },
   danger: {
     backgroundColor: {
-      default: '#dc2626',
-      ':hover': '#b91c1c',
+      default: color.buttonDangerBg,
+      ':hover': color.buttonDangerBgHover,
     },
-    color: '#ffffff',
+    color: color.buttonDangerColor,
     outlineColor: {
       default: 'transparent',
-      ':focus-visible': '#ef4444',
+      ':focus-visible': color.buttonDangerOutline,
     },
   },
   ghost: {
     backgroundColor: 'transparent',
     color: {
-      default: '#2563eb',
-      ':hover': '#1e40af',
+      default: color.textAccent,
+      ':hover': color.textAccentHover,
     },
     paddingBlock: 0,
     paddingInline: 0,
     outlineColor: {
       default: 'transparent',
-      ':focus-visible': '#3b82f6',
+      ':focus-visible': color.buttonPrimaryOutline,
     },
   },
   icon: {
     backgroundColor: 'transparent',
-    paddingBlock: 4,
-    paddingInline: 4,
-    borderRadius: 4,
+    paddingBlock: spacing.xs,
+    paddingInline: spacing.xs,
+    borderRadius: borderRadius.sm,
     outlineColor: {
       default: 'transparent',
-      ':focus-visible': '#3b82f6',
+      ':focus-visible': color.buttonPrimaryOutline,
     },
   },
 });

--- a/app/components/ExerciseFilters.tsx
+++ b/app/components/ExerciseFilters.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '~/components/Button';
 import type { ExerciseTypeOption } from '~/types';
 
 type ExerciseFiltersProps = {
@@ -53,13 +54,9 @@ export function ExerciseFilters({
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold text-gray-900">{t('exercises.filterTitle')}</h2>
         {hasActiveFilters && (
-          <button
-            type="button"
-            onClick={onClearFilters}
-            className="text-sm text-blue-600 hover:text-blue-800"
-          >
+          <Button type="button" variant="ghost" onClick={onClearFilters}>
             {t('exercises.clearFilters')}
-          </button>
+          </Button>
         )}
       </div>
 
@@ -92,13 +89,13 @@ export function ExerciseFilters({
         </div>
 
         {/* Toggle Advanced Filters */}
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
-          className="text-sm text-blue-600 hover:text-blue-800 font-medium"
         >
           {showAdvancedFilters ? t('exercises.lessFilters') : t('exercises.moreFilters')}
-        </button>
+        </Button>
 
         {/* Exercise Type Checkboxes */}
         <div

--- a/app/components/ExerciseForm.tsx
+++ b/app/components/ExerciseForm.tsx
@@ -1,4 +1,5 @@
 import * as stylex from '@stylexjs/stylex';
+import { color } from '~/styles/tokens.stylex';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { Exercise } from '@prisma/client';
@@ -333,8 +334,8 @@ export function ExerciseForm({
 const formStyles = stylex.create({
   dangerGhost: {
     color: {
-      default: '#dc2626',
-      ':hover': '#991b1b',
+      default: color.textDanger,
+      ':hover': color.textDangerHover,
     },
   },
 });

--- a/app/components/ExerciseForm.tsx
+++ b/app/components/ExerciseForm.tsx
@@ -1,3 +1,4 @@
+import * as stylex from '@stylexjs/stylex';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { Exercise } from '@prisma/client';
@@ -8,6 +9,7 @@ import type MDEditor from '@uiw/react-md-editor';
 import { isValidYouTubeInput } from '~/utils/youtube';
 import { useTranslation } from 'react-i18next';
 import { Form } from 'react-router';
+import { Button } from '~/components/Button';
 
 type SerializedExercise = Omit<Exercise, 'createdAt' | 'updatedAt'> & {
   createdAt: Date;
@@ -229,16 +231,17 @@ export function ExerciseForm({
                   {exercise.image}
                 </a>
               </p>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => {
                   setImageToRemove(exercise.image);
                   setShowRemoveDialog(true);
                 }}
-                className="text-sm text-red-600 hover:text-red-800 font-medium"
+                style={formStyles.dangerGhost}
               >
                 {t('exercises.remove')}
-              </button>
+              </Button>
             </div>
           )}
           {imageToRemove && (
@@ -283,21 +286,11 @@ export function ExerciseForm({
 
         <div className="flex justify-end gap-3">
           {showSaveAndContinue && (
-            <button
-              type="submit"
-              name="saveAndContinue"
-              value="true"
-              className="rounded-md bg-gray-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
-            >
+            <Button type="submit" name="saveAndContinue" value="true" variant="secondary">
               {t('exercises.saveAndContinue')}
-            </button>
+            </Button>
           )}
-          <button
-            type="submit"
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-          >
-            {submitText || t('common.save')}
-          </button>
+          <Button type="submit">{submitText || t('common.save')}</Button>
         </div>
       </Form>
 
@@ -310,25 +303,25 @@ export function ExerciseForm({
             </h3>
             <p className="text-gray-600 mb-6">{t('exercises.removeImageConfirm')}</p>
             <div className="flex justify-end gap-3">
-              <button
+              <Button
                 type="button"
+                variant="secondary"
                 onClick={() => {
                   setShowRemoveDialog(false);
                   setImageToRemove(null);
                 }}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200"
               >
                 {t('common.cancel')}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="danger"
                 onClick={() => {
                   setShowRemoveDialog(false);
                 }}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700"
               >
                 {t('exercises.remove')}
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -336,3 +329,12 @@ export function ExerciseForm({
     </div>
   );
 }
+
+const formStyles = stylex.create({
+  dangerGhost: {
+    color: {
+      default: '#dc2626',
+      ':hover': '#991b1b',
+    },
+  },
+});

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,4 +1,5 @@
 import * as stylex from '@stylexjs/stylex';
+import { fontWeight } from '~/styles/constants.stylex';
 import { useTranslation } from 'react-i18next';
 import { Button } from '~/components/Button';
 
@@ -31,7 +32,7 @@ export default function LanguageSwitcher() {
 
 const styles = stylex.create({
   active: {
-    fontWeight: 700,
+    fontWeight: fontWeight.bold,
     textDecorationLine: 'underline',
   },
 });

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,4 +1,6 @@
+import * as stylex from '@stylexjs/stylex';
 import { useTranslation } from 'react-i18next';
+import { Button } from '~/components/Button';
 
 export default function LanguageSwitcher() {
   const { i18n } = useTranslation();
@@ -9,18 +11,27 @@ export default function LanguageSwitcher() {
 
   return (
     <div className="language-switcher">
-      <button
+      <Button
+        variant="ghost"
         onClick={() => changeLanguage('fi')}
-        className={i18n.language === 'fi' ? 'active' : ''}
+        style={i18n.language === 'fi' && styles.active}
       >
         FI
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="ghost"
         onClick={() => changeLanguage('en')}
-        className={i18n.language === 'en' ? 'active' : ''}
+        style={i18n.language === 'en' && styles.active}
       >
         EN
-      </button>
+      </Button>
     </div>
   );
 }
+
+const styles = stylex.create({
+  active: {
+    fontWeight: 700,
+    textDecorationLine: 'underline',
+  },
+});

--- a/app/components/PractiseSessionSection.tsx
+++ b/app/components/PractiseSessionSection.tsx
@@ -1,5 +1,7 @@
+import * as stylex from '@stylexjs/stylex';
 import { useState } from 'react';
 import type { Section, PractiseLength, SelectedItem } from '~/types';
+import { Button } from '~/components/Button';
 import { useTranslation } from 'react-i18next';
 
 type PractiseSessionSectionProps = {
@@ -142,14 +144,9 @@ export function PractiseSessionSection({
           </select>
         )}
 
-        <button
-          type="button"
-          onClick={handleAdd}
-          disabled={!canAdd}
-          className="rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
-        >
+        <Button type="button" onClick={handleAdd} disabled={!canAdd}>
           {t('common.add', 'Add')}
-        </button>
+        </Button>
       </div>
 
       {/* Selected items list */}
@@ -161,14 +158,15 @@ export function PractiseSessionSection({
               className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2"
             >
               <span className="text-gray-700">• {getItemLabel(item)}</span>
-              <button
+              <Button
                 type="button"
+                variant="icon"
                 onClick={() => onRemoveItem(item.itemValue, item.exerciseId)}
-                className="text-red-600 hover:text-red-800 font-bold"
                 aria-label={`Remove ${getItemLabel(item)}`}
+                style={removeStyles.button}
               >
                 ×
-              </button>
+              </Button>
             </li>
           ))}
         </ul>
@@ -182,3 +180,14 @@ export function PractiseSessionSection({
     </div>
   );
 }
+
+const removeStyles = stylex.create({
+  button: {
+    color: {
+      default: '#dc2626',
+      ':hover': '#991b1b',
+    },
+    fontWeight: 700,
+    fontSize: 18,
+  },
+});

--- a/app/components/PractiseSessionSection.tsx
+++ b/app/components/PractiseSessionSection.tsx
@@ -1,4 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
+import { color } from '~/styles/tokens.stylex';
+import { fontSize, fontWeight } from '~/styles/constants.stylex';
 import { useState } from 'react';
 import type { Section, PractiseLength, SelectedItem } from '~/types';
 import { Button } from '~/components/Button';
@@ -184,10 +186,10 @@ export function PractiseSessionSection({
 const removeStyles = stylex.create({
   button: {
     color: {
-      default: '#dc2626',
-      ':hover': '#991b1b',
+      default: color.textDanger,
+      ':hover': color.textDangerHover,
     },
-    fontWeight: 700,
-    fontSize: 18,
+    fontWeight: fontWeight.bold,
+    fontSize: fontSize.lg,
   },
 });

--- a/app/components/PractiseSessionSummary.tsx
+++ b/app/components/PractiseSessionSummary.tsx
@@ -1,4 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
+import { color } from '~/styles/tokens.stylex';
+import { borderRadius, fontSize, fontWeight, spacing } from '~/styles/constants.stylex';
 
 import type { PractiseLength } from '~/types';
 
@@ -56,70 +58,70 @@ export function PractiseSessionSummary({
 
 const styles = stylex.create({
   container: {
-    borderRadius: 8,
+    borderRadius: borderRadius.lg,
     borderWidth: 2,
     borderStyle: 'solid',
-    borderColor: '#d1d5db',
-    backgroundColor: '#f9fafb',
-    padding: 16,
+    borderColor: color.borderDefault,
+    backgroundColor: color.bgSecondary,
+    padding: spacing.md,
   },
   heading: {
-    marginBottom: 12,
-    fontSize: 18,
-    fontWeight: 600,
+    marginBottom: spacing.sm,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
   },
   rows: {
     display: 'flex',
     flexDirection: 'column',
-    gap: 8,
+    gap: spacing.sm,
   },
   row: {
     display: 'flex',
     justifyContent: 'space-between',
   },
   label: {
-    color: '#374151',
+    color: color.textSecondary,
   },
   value: {
-    fontWeight: 600,
+    fontWeight: fontWeight.semibold,
   },
   dividerRow: {
     display: 'flex',
     justifyContent: 'space-between',
     borderTopWidth: 1,
     borderTopStyle: 'solid',
-    borderTopColor: '#e5e7eb',
-    paddingTop: 8,
+    borderTopColor: color.borderLight,
+    paddingTop: spacing.sm,
   },
   remainingGreen: {
-    fontWeight: 700,
-    color: '#16a34a',
+    fontWeight: fontWeight.bold,
+    color: color.textSuccess,
   },
   remainingRed: {
-    fontWeight: 700,
-    color: '#dc2626',
+    fontWeight: fontWeight.bold,
+    color: color.textDanger,
   },
   progressContainer: {
-    marginTop: 16,
+    marginTop: spacing.md,
   },
   progressTrack: {
     height: 12,
     width: '100%',
     overflow: 'hidden',
-    borderRadius: 9999,
-    backgroundColor: '#e5e7eb',
+    borderRadius: borderRadius.full,
+    backgroundColor: color.progressTrack,
   },
   progressBar: (width: string, isOver: boolean) => ({
     height: '100%',
     transitionProperty: 'all',
     transitionDuration: '0.15s',
-    backgroundColor: isOver ? '#ef4444' : '#22c55e',
+    backgroundColor: isOver ? color.progressDanger : color.progressSuccess,
     width,
   }),
   percentLabel: {
-    marginTop: 4,
-    fontSize: 12,
-    color: '#4b5563',
+    marginTop: spacing.xs,
+    fontSize: fontSize.xs,
+    color: color.textMuted,
     textAlign: 'center',
   },
 });

--- a/app/pages/EditPractiseSessionPage.tsx
+++ b/app/pages/EditPractiseSessionPage.tsx
@@ -4,6 +4,7 @@ import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
 import { PractiseSessionSummary } from '~/components/PractiseSessionSummary';
+import { Button } from '~/components/Button';
 import { useTranslation } from 'react-i18next';
 
 type PracticeSessionData = {
@@ -213,19 +214,10 @@ export default function EditPractiseSessionPage({
         <div className="mt-6">
           {errors.items && <p className="text-sm text-red-600 mb-2">{errors.items}</p>}
           <div className="flex justify-between">
-            <button
-              type="button"
-              onClick={handleDeleteClick}
-              className="px-6 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-            >
+            <Button type="button" variant="danger" onClick={handleDeleteClick}>
               {t('sessions.delete')}
-            </button>
-            <button
-              type="submit"
-              className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              {t('sessions.update')}
-            </button>
+            </Button>
+            <Button type="submit">{t('sessions.update')}</Button>
           </div>
         </div>
       </Form>
@@ -237,20 +229,12 @@ export default function EditPractiseSessionPage({
             <h2 className="text-xl font-bold mb-4">{t('sessions.delete')}</h2>
             <p className="text-gray-700 mb-6">{t('sessions.deleteConfirm')}</p>
             <div className="flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={handleDeleteCancel}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
+              <Button type="button" variant="secondary" onClick={handleDeleteCancel}>
                 {t('common.cancel')}
-              </button>
-              <button
-                type="button"
-                onClick={handleDeleteConfirm}
-                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-              >
+              </Button>
+              <Button type="button" variant="danger" onClick={handleDeleteConfirm}>
                 {t('common.delete')}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/app/pages/ExercisesListPage.tsx
+++ b/app/pages/ExercisesListPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import * as stylex from '@stylexjs/stylex';
+import { color } from '~/styles/tokens.stylex';
 import { Link, useNavigation, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ExerciseFilters as ExerciseFiltersComponent } from '~/components/ExerciseFilters';
@@ -223,8 +224,8 @@ export default function ExercisesListPage({
 const dismissStyles = stylex.create({
   button: {
     color: {
-      default: '#16a34a',
-      ':hover': '#166534',
+      default: color.textSuccess,
+      ':hover': color.textSuccessHover,
     },
   },
 });

--- a/app/pages/ExercisesListPage.tsx
+++ b/app/pages/ExercisesListPage.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
+import * as stylex from '@stylexjs/stylex';
 import { Link, useNavigation, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ExerciseFilters as ExerciseFiltersComponent } from '~/components/ExerciseFilters';
+import { Button } from '~/components/Button';
 import { useExerciseFilters } from '~/hooks/useExerciseFilters';
 import type { ExerciseWithTypePath } from '~/services/exercises.server';
 import type { ExerciseTypeOption } from '~/types';
@@ -70,10 +72,11 @@ export default function ExercisesListPage({
         <div className="mb-4 rounded-md bg-green-50 p-4">
           <div className="flex items-center justify-between">
             <p className="text-sm text-green-800">{t('exercises.deleteSuccess')}</p>
-            <button
+            <Button
+              variant="icon"
               onClick={() => setShowDeleteSuccess(false)}
-              className="text-green-600 hover:text-green-800"
               aria-label="Dismiss"
+              style={dismissStyles.button}
             >
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                 <path
@@ -82,7 +85,7 @@ export default function ExercisesListPage({
                   clipRule="evenodd"
                 />
               </svg>
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -148,13 +151,9 @@ export default function ExercisesListPage({
             <p className="mt-1 text-sm text-gray-500">{t('exercises.adjustFilters')}</p>
             {hasActiveFilters && (
               <div className="mt-6">
-                <button
-                  type="button"
-                  onClick={clearFilters}
-                  className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                >
+                <Button type="button" onClick={clearFilters}>
                   {t('exercises.clearAllFilters')}
-                </button>
+                </Button>
               </div>
             )}
           </div>
@@ -220,3 +219,12 @@ export default function ExercisesListPage({
     </div>
   );
 }
+
+const dismissStyles = stylex.create({
+  button: {
+    color: {
+      default: '#16a34a',
+      ':hover': '#166534',
+    },
+  },
+});

--- a/app/pages/PractiseSessionForm.tsx
+++ b/app/pages/PractiseSessionForm.tsx
@@ -4,6 +4,7 @@ import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
 import { PractiseSessionSummary } from '~/components/PractiseSessionSummary';
+import { Button } from '~/components/Button';
 import { useTranslation } from 'react-i18next';
 
 type PractiseSessionFormProps = {
@@ -159,12 +160,7 @@ export default function PractiseSessionForm({ sections }: PractiseSessionFormPro
         <div className="mt-6">
           {errors.items && <p className="text-sm text-red-600 mb-2">{errors.items}</p>}
           <div className="flex justify-end">
-            <button
-              type="submit"
-              className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              {t('sessions.save')}
-            </button>
+            <Button type="submit">{t('sessions.save')}</Button>
           </div>
         </div>
       </Form>

--- a/app/styles/constants.stylex.ts
+++ b/app/styles/constants.stylex.ts
@@ -1,0 +1,36 @@
+import * as stylex from '@stylexjs/stylex';
+
+export const borderRadius = stylex.defineConsts({
+  xs: '2px',
+  sm: '4px',
+  md: '6px',
+  lg: '8px',
+  full: '9999px',
+});
+
+export const spacing = stylex.defineConsts({
+  xxs: '2px',
+  xs: '4px',
+  sm: '8px',
+  md: '16px',
+  lg: '24px',
+  xl: '32px',
+  xxl: '48px',
+});
+
+export const fontSize = stylex.defineConsts({
+  xs: '12px',
+  sm: '14px',
+  base: '16px',
+  lg: '18px',
+  xl: '20px',
+  '2xl': '24px',
+  '3xl': '30px',
+});
+
+export const fontWeight = stylex.defineConsts({
+  normal: '400',
+  medium: '500',
+  semibold: '600',
+  bold: '700',
+});

--- a/app/styles/tokens.stylex.ts
+++ b/app/styles/tokens.stylex.ts
@@ -1,0 +1,65 @@
+import * as stylex from '@stylexjs/stylex';
+
+export const color = stylex.defineVars({
+  // Text
+  textPrimary: '#111827',
+  textSecondary: '#374151',
+  textMuted: '#4b5563',
+  textFaint: '#6b7280',
+  textOnColor: '#ffffff',
+  textAccent: '#2563eb',
+  textAccentHover: '#1e40af',
+  textDanger: '#dc2626',
+  textDangerHover: '#991b1b',
+  textSuccess: '#16a34a',
+  textSuccessHover: '#166534',
+  textWarning: '#d97706',
+
+  // Background
+  bgPrimary: '#ffffff',
+  bgSecondary: '#f9fafb',
+  bgMuted: '#f3f4f6',
+  bgOverlay: 'rgba(0, 0, 0, 0.5)',
+
+  // Border
+  borderDefault: '#d1d5db',
+  borderLight: '#e5e7eb',
+  borderHover: '#9ca3af',
+
+  // Button - Primary
+  buttonPrimaryColor: '#ffffff',
+  buttonPrimaryBg: '#2563eb',
+  buttonPrimaryBgHover: '#1d4ed8',
+  buttonPrimaryOutline: '#3b82f6',
+
+  // Button - Secondary
+  buttonSecondaryColor: '#374151',
+  buttonSecondaryBg: '#ffffff',
+  buttonSecondaryBgHover: '#f9fafb',
+  buttonSecondaryBorder: '#d1d5db',
+  buttonSecondaryOutline: '#3b82f6',
+
+  // Button - Danger
+  buttonDangerColor: '#ffffff',
+  buttonDangerBg: '#dc2626',
+  buttonDangerBgHover: '#b91c1c',
+  buttonDangerOutline: '#ef4444',
+
+  // Accent
+  accentBg: '#eff6ff',
+  accentBorder: '#3b82f6',
+  accentBadgeBg: '#dbeafe',
+  accentBadgeText: '#1e40af',
+
+  // Success
+  successBg: '#f0fdf4',
+  successText: '#166534',
+
+  // Danger
+  dangerBg: '#fef2f2',
+
+  // Progress
+  progressTrack: '#e5e7eb',
+  progressSuccess: '#22c55e',
+  progressDanger: '#ef4444',
+});

--- a/docs/stylex.md
+++ b/docs/stylex.md
@@ -1,0 +1,115 @@
+# Stylex
+
+My plan is to start converting tailwind styles to stylex styles.
+
+First step is to install and configure stylex.
+
+For installation, read https://github.com/facebook/stylex/blob/main/packages/docs/static/llm/stylex-installation.md
+
+Next step is to select a small component and convert it to use stylex so that we can verify Stylex works as
+expected. I suggest you use /Users/janimattiellonen/Documents/Development/Frisbeegolf/Harkkapankki/app/components/PractiseSessionSummary.tsx.
+
+Instructions on how to properly use Stylex can be found at https://github.com/facebook/stylex/blob/main/packages/docs/static/llm/stylex-authoring.md
+
+I'm comparing your stylex setup against another React Router 7 setup.
+
+Here are some differences:
+
+package.json:
+
+Us:
+"@stylexjs/unplugin": "^0.18.2",
+
+Them:
+"vite-plugin-stylex": "^0.13.0",
+
+vite.config.ts:
+
+Us:
+
+```
+import { vite as stylexVite } from '@stylexjs/unplugin';
+...
+  plugins: [
+    stylexVite({
+      useCSSLayers: true,
+    }),
+    reactRouter(),
+    tsconfigPaths(),
+  ],
+
+```
+
+Them:
+
+```
+import stylex from "vite-plugin-stylex";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+const stylexPlugin = stylex({
+  aliases: {
+    "~/*": [path.resolve(__dirname, "app", "*")],
+  },
+});
+
+// biome-ignore lint/style/noDefaultExport: Vite needs default export.
+export default defineConfig({
+  plugins: [reactRouter(), stylexPlugin],
+  resolve: {
+    tsconfigPaths: true,
+  },
+});
+
+```
+
+## Button component
+
+Replace <button> in /Users/janimattiellonen/Documents/Development/Frisbeegolf/Harkkapankki/app/pages/EditExercisePage.tsx
+with a Button component (app/components/Button.tsx). In addition to that, style the new button component using Stylex.
+
+Create common variants such as primary and secondary.
+
+Replace all instances of <button>'s in this project with the new component
+
+## Theme
+
+Create a stylex token file with that contains generally used values like:
+
+- borderRadius
+- padding
+- fontSize
+- fontWeight
+- colors
+
+### Colors
+
+Never use specific colors directly in code. Create semantical color params that are then used.
+
+For example (as an example, color names in the example isn't a must):
+
+```
+export const theme = defineVars({
+  // Text
+  textPrimary: color.ink90,
+  textMuted: color.ink60,
+  textAccent: color.indigo50,
+  textDanger: color.red50,
+
+  // Border
+  border: color.ink30,
+  borderHover: color.ink40,
+  // Button
+  buttonPrimaryColor: color.neutral100,
+  buttonPrimaryBackground: color.indigo50,
+  buttonPrimaryBackgroundHover: color.indigo40,
+  buttonPrimaryBackgroundActive: color.indigo60,
+  buttonPrimaryOutline: color.indigo50,
+
+  buttonSecondaryColor: color.ink90,
+  buttonSecondaryBackground: color.ink10,
+  buttonSecondaryBackgroundHover: color.ink20,
+  buttonSecondaryBorder: color.ink60,
+  buttonSecondaryOutline: color.ink60,
+
+```

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   plugins: [
     // eslint-disable-next-line import/no-named-as-default-member
     stylexUnplugin.vite({
-      useCSSLayers: true,
+      useCSSLayers: false,
       aliases: {
         '~/*': [path.resolve(__dirname, 'app', '*')],
       },


### PR DESCRIPTION
## Summary
- Replace remaining native `<button>` elements with the reusable `Button` component
- Introduce StyleX token files (`tokens.stylex.ts`, `constants.stylex.ts`) for colors, spacing, font sizes, font weights, and border radii
- Refactor components to consume tokens instead of inline literal values
- Add `docs/stylex.md` describing the token approach

## Test plan
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] Visual check: Button variants (primary, secondary, danger, ghost, icon) render correctly
- [ ] Visual check: ExerciseForm, LanguageSwitcher, PractiseSessionSection, PractiseSessionSummary, ExercisesListPage look unchanged
- [ ] Hover and focus states behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)