### PR TITLE
Add project vision and season planning plan docs

### DIFF
--- a/docs/18 - season planning feature plan.md
+++ b/docs/18 - season planning feature plan.md
@@ -1,0 +1,144 @@
+# Season planning feature — plan
+
+This is the design plan for the season planning feature. Doc 16 (exercise type hierarchy changes) is a prerequisite and has already been resolved.
+
+## Why this feature
+
+The personal goal of Harkkapankki is to make weekly junior practice planning fast and dependable. The longer-term goal is to plan a **whole season** of practices: a sequence of weekly sessions that vary deliberately and progress logically. This document is the first step toward that longer-term goal.
+
+The author runs weekly sessions for under-18 juniors between April and October. A season is roughly 20–25 weeks but the exact end is rarely known in advance — previous seasons have ended in mid-October. Sessions are normally weekly on a fixed weekday and time (example: Wednesdays, 17:00–18:30, 1.5 hours), but the day, time, and length may vary between seasons. Within a season the cadence may have gaps for vacation, sick days, or canceled sessions.
+
+## Context — current data model (summary)
+
+The full report from the data-model exploration is summarised here:
+
+- **DB**: PostgreSQL via Prisma.
+- **PracticeSession**: top-level row with `name`, `description`, `sessionLength` (60 or 90), unique `slug`, and `createdAt` / `updatedAt`. No parent.
+- **PracticeSessionSectionItem**: join row linking a session to a (section, exercise type, optional exercise) with an `order`.
+- **Section**: 5 fixed sections, stored in DB rows with order; translated via `SectionTranslation`.
+- **SectionDurationConfig**: per-(section, sessionLength) duration in minutes. Two rows per section, one for 60 min and one for 90 min.
+- **ExerciseType**: hierarchical (self-FK `parentId`); translated via `ExerciseTypeTranslation`.
+- **Exercise**: leaf items with `name`, `description`, rich `content`, `image`, `youtubeVideo`, `duration`, FK to `ExerciseType`.
+- **No User / Auth table.** All data is global.
+- **No soft-delete fields anywhere.** Most FKs cascade on delete; the exception is `PracticeSessionSectionItem.exerciseId`, which uses `onDelete: SetNull` so past sessions remain valid when an exercise is deleted (the row keeps its session, section, and exercise type — only the specific drill reference becomes null).
+
+The schema is well-normalized and extending it for seasons is mostly additive.
+
+## Decisions (settled)
+
+1. **Season is a first-class entity.** A new `Season` table will be added.
+2. **Sessions are scheduled to specific dates.** A `scheduledAt` (datetime) field will be added to `PracticeSession`. Nullable, so sessions without a planned date are valid (drafts).
+3. **Session lengths stay 60 / 90.** Generalising the duration model is deferred until a real need appears.
+4. **Existing standalone sessions are left as-is.** They get `seasonId = NULL` after migration. They are example data and don't need backfilling into a season.
+5. **Doc 16 is resolved.** Season planning UI builds on top of the resolved exercise type hierarchy work; there is no in-flux session-designer dependency.
+
+## Schema changes
+
+### New table: `Season`
+
+```prisma
+model Season {
+  id                  String   @id @default(uuid())
+  slug                String   @unique
+  name                String
+  description         String?
+  startDate           DateTime?
+  endDate             DateTime?
+  defaultDayOfWeek    Int?     // 0-6, used to seed dates for new sessions
+  defaultStartTime    String?  // "17:00"
+  defaultDurationMin  Int?     // 60 or 90
+  practiceSessions    PracticeSession[]
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+}
+```
+
+Notes:
+
+- `endDate` is nullable because seasons rarely have a known end date in advance.
+- Defaults (`defaultDayOfWeek`, `defaultStartTime`, `defaultDurationMin`) are used when creating new sessions inside the season — each session can still override them.
+- `slug` follows the existing global-unique pattern (`slugify` + `makeUniqueSlug`).
+
+### Additions to `PracticeSession`
+
+```prisma
+seasonId    String?   @map("season_id")
+season      Season?   @relation(fields: [seasonId], references: [id], onDelete: SetNull)
+scheduledAt DateTime? @map("scheduled_at")
+```
+
+Notes:
+
+- `seasonId` is nullable. Existing seasonless sessions remain valid.
+- `onDelete: SetNull` means deleting a season does not delete its sessions — they fall back to standalone. Safer default than cascade. Worth confirming when this is implemented.
+- `scheduledAt` is nullable. Sessions without a date are drafts and sort to the end of the season list.
+- **No `weekNumber` column.** Both calendar week and "session N of the season" can be derived from `scheduledAt` at view time (`getISOWeek(scheduledAt)` and `row_number() over (partition by seasonId order by scheduledAt)` respectively). Storing it would create an integrity problem when sessions are reordered or rescheduled.
+
+### Migration approach
+
+- One Prisma migration adds the `Season` table and the three columns on `PracticeSession`.
+- No data backfill — all existing rows get `NULL` for the new columns.
+- No new index strictly required for Phase 1; revisit if season-scoped queries get slow.
+
+## Code changes (high-level)
+
+### Repositories / services
+
+- New: `app/repositories/season.server.ts` (CRUD).
+- New: `app/services/seasons.server.ts` (slug generation, date seeding from defaults, anything cross-cutting).
+- Update: `app/repositories/practiceSession.server.ts` — accept optional `seasonId` filter and `scheduledAt` field on writes.
+
+### Routes
+
+- `/seasons` — list of seasons (name, date range, session count).
+- `/seasons/new` — create-season form (name, description, optional dates, defaults).
+- `/seasons/$slug` — season overview: list of sessions ordered by `scheduledAt`, calendar view, "add sessions" action.
+- `/seasons/$slug/edit` — edit season metadata.
+- `/practise-sessions/new?seasonId=...` — existing form, prefilled with season defaults.
+- `/practise-sessions/$slug` — existing detail view, with a back-link to its season when one is set.
+
+### Forms
+
+- `PractiseSessionForm` gains an optional `scheduledAt` field and shows "part of season X" when `seasonId` is set.
+- New `SeasonForm` for create/edit.
+
+### "Add sessions" UX (Phase 1)
+
+- Inside `/seasons/$slug`, an action to add multiple sessions at once.
+- Calendar UI showing the next ~20 occurrences of the season's `defaultDayOfWeek` starting from today.
+- Each occurrence is toggleable (click to add / remove a session for that date).
+- Each toggled-on date creates a `PracticeSession` with `scheduledAt` set, `seasonId` set, `sessionLength` = season's `defaultDurationMin`, and an empty section-item list ready to be filled in later.
+- The user can then click any session to design its content via the existing session designer.
+
+### i18n
+
+- New translation keys for season UI (FI + EN).
+- Same translation strategy as existing entities — keys in `/public/locales/{fi,en}.json`.
+
+### Slugs
+
+- Keep the existing global-unique pattern. Two seasons named "Week 1" become `week-1` and `week-1-2`.
+- Nested URLs (`/seasons/spring-2026/week-1`) are a future polish, not a Phase 1 concern.
+
+## Phased rollout
+
+- **Phase 0** — _resolved._ Doc 16 (exercise type hierarchy) is done; the session designer UI is stable.
+- **Phase 1** — Season CRUD. Sessions can be attached to a season. `scheduledAt` per session. "Add sessions" calendar action. Session lists filterable by season. **This phase delivers the personal goal.**
+- **Phase 2** — Coverage stats. Read-only "what you've covered" view per season: which exercise types appear in which sessions, frequency, gaps. No suggestions yet — just visibility.
+- **Phase 3** — Smart suggestions. The system warns when a season is unbalanced ("no putting in last 3 sessions") or repeats too quickly. Coach decides what to do; nothing enforced.
+- **Phase 4** — Auto-generation. The system can propose a full season plan given a target group and a time window. **This is the north star.**
+
+## Issues / blockers / risks
+
+1. **Content shortage.** The exercise bank covers a fraction of junnufriba.fi today. Variety/repetition logic in Phase 2+ will produce weak signals until coverage improves. Doesn't block Phase 1.
+2. **No auth.** Fine for solo use. If junnufriba ever runs the project for multiple coaches, "my season" needs a User table — out of scope here, noted for the longer term.
+3. **Calendar/timezone correctness.** `scheduledAt` is a `DateTime` — needs care around timezone handling at form submission, especially for daylight-saving transitions in spring/autumn (the project's coaching season spans both DST changes in Finland). Worth a small explicit decision: store in UTC, render in Europe/Helsinki, accept user input as Helsinki-local.
+
+## Open implementation details to settle later
+
+These are not schema or design decisions — they're UX/UI choices that don't change the database and can be settled when Phase 1 is being built:
+
+- Visual treatment of the calendar in "Add sessions" (grid? list? inline calendar component?).
+- Should past sessions be visually de-emphasised in the season overview?
+- What does the season list look like when there are no seasons yet (empty state)?
+- Should deleting a season prompt about its sessions ("convert to standalone" vs "delete with season")? — `onDelete: SetNull` makes "convert to standalone" the default behavior; the prompt would just confirm.

--- a/docs/Project summary.md
+++ b/docs/Project summary.md
@@ -1,0 +1,227 @@
+# Harkkapankki — Project Summary
+
+## Why Harkkapankki exists
+
+Between April and October, the project's author runs weekly disc golf training sessions for under-18 juniors. Each session follows the same arc — introduction, warm-up, putting, throwing, closing — but the _content_ needs to be different every week, and a new programme is usually put together the day before, sometimes only hours before. That recurring last-minute planning chore is the original problem the application is meant to solve.
+
+### The personal goal
+
+Make weekly session planning fast and dependable: open the app, pick exercises from a personal bank, and have a balanced 60- or 90-minute session ready in minutes instead of starting from a blank page every Sunday evening.
+
+### The longer-term goal
+
+Eventually the application should plan not just _one_ session but a **whole season** — a sequence of weekly sessions that vary deliberately (so no two practices feel the same) and progress logically (so techniques are introduced and built on in a sensible order). This is the north star, not the current state.
+
+### The bigger picture: junnufriba.fi
+
+The Finnish junior disc golf community already has a shared resource at [junnufriba.fi](https://junnufriba.fi). Harkkapankki is being built as an improved successor — similar content, but with proper tooling for browsing the exercise bank and assembling sessions out of it. Once the project is solid enough, the intention is to **offer it to the owner of junnufriba.fi free of charge**, as a contribution to Finnish junior disc golf coaching. There is no commercial intent behind the project.
+
+---
+
+## What is Harkkapankki?
+
+**Harkkapankki** (Finnish for "Practice Bank") is a web application that helps disc golf coaches and players plan structured practice sessions and maintain a library of training exercises. Instead of writing training plans on paper or in scattered documents, users can build a personal — or shared — collection of disc golf drills, then assemble them into ready-to-run practice sessions of a chosen length.
+
+The application is aimed at junior coaches, club trainers, and serious players who want a repeatable, organised way to plan and run training. It is currently available in **Finnish and English**, and the user can switch between languages at any time.
+
+---
+
+## What the application does, in plain language
+
+At the highest level, Harkkapankki provides three things:
+
+1. **An exercise bank** — a searchable, filterable library of disc golf training drills.
+2. **A practice session designer** — a tool for putting together a complete, time-balanced training session from those drills.
+3. **A library of saved practice sessions** — every session the user designs can be saved, reopened, edited, and reused.
+
+The home page surfaces these three core activities directly: _Design a practice session_, _Exercise bank_, and _Create a new exercise_.
+
+---
+
+## Feature 1 — The Exercise Bank
+
+The exercise bank is where individual training drills live. Each exercise is a self-contained training instruction that a coach or player can read, follow, and reuse in any number of practice sessions.
+
+### What information an exercise contains
+
+Each exercise stores:
+
+- **A name** — the title of the drill (for example, "Putting from 5 metres" or "Backhand grip basics").
+- **A short description** — a one- or two-line summary that appears in lists and search results.
+- **Detailed content** — the full instructions for the drill, written in a rich text editor that supports formatted text, lists, headings, and embedded YouTube videos.
+- **An image** (optional) — a photo or diagram illustrating the drill. Users can upload images directly and replace or remove them later.
+- **A YouTube tutorial link** (optional) — a link to a video demonstration.
+- **A duration** — how many minutes the drill is expected to take.
+- **An exercise type** — a category that places the drill within the project's training taxonomy (see below).
+
+### Exercise categories (the type hierarchy)
+
+Exercises are organised into a two-level category tree so they can be found and filtered by topic. The current categories are:
+
+- **Technique**
+  - Backhand
+  - Sidearm (forehand)
+  - Putting
+  - Driving
+- **Supplementary exercises**
+  - Motor skills exercises
+  - Strength training
+  - Warm-up exercises
+  - Muscle condition
+- **Games, plays and challenges**
+  - Throwing games
+  - Warm-up games
+  - Putting games
+
+Every exercise is assigned to one of these categories or sub-categories, which keeps the bank organised as it grows.
+
+### Browsing, searching and filtering
+
+The exercise list page is the user's main way to explore the bank. It offers:
+
+- **A list of all exercises**, each shown as a card with the exercise's name, creation date, type path (e.g. _Technique › Backhand_), short description, thumbnail image, and duration.
+- **Search by title** — a search box that filters the list to exercises whose names match the typed text. The user is prompted to type at least three characters before the search becomes meaningful.
+- **Filter by exercise type** — an expandable "More filters" panel with checkboxes for each category and sub-category. Users can pick a whole category (e.g. _Technique_) or zoom in on specific sub-categories (e.g. _Putting_ only). Parent checkboxes show an indeterminate state when only some of their children are selected.
+- **A "Clear filters" button** for quickly returning to the full list.
+- **An empty-state message** that explains what to do when filters return no results.
+- **Loading indicators** while the page is fetching results.
+
+### Creating, editing and deleting exercises
+
+From the exercise list, users can:
+
+- **Add a new exercise** through a dedicated form. The form validates input as the user types, requires the most important fields, and asks for a category before saving.
+- **Edit an existing exercise** by opening its detail page and clicking _Edit_. All fields can be changed, including swapping or removing the image.
+- **Save and continue** when creating an exercise — a convenience option that lets the user save the current drill and immediately start writing a new one, useful when entering many exercises in a row.
+- **Delete an exercise**, with a confirmation dialog warning that the action is permanent. Successful deletions show a confirmation banner on the list page.
+- **Remove an attached image** with a confirmation dialog, with a clear warning that the change is applied when the form is saved.
+
+### Reading an exercise
+
+Opening an exercise reveals a detail page showing:
+
+- The exercise's name and creation date.
+- The full description and rich-text content, with any embedded YouTube videos rendered inline.
+- The full image (when one is attached).
+- The duration in minutes.
+- The category path the exercise belongs to.
+- A separate link to the YouTube tutorial, when present.
+- An _Edit_ button for jumping to the edit form.
+
+---
+
+## Feature 2 — The Practice Session Designer
+
+The session designer is where individual exercises and exercise types come together to form a real, runnable training session.
+
+### Choosing the length of the session
+
+Every practice session is either **60 minutes** or **90 minutes** long. The user picks the length first, and the rest of the page reacts to that choice — every section's allocated time updates automatically.
+
+### Naming and describing the session
+
+Each session must have a **name** (required) and may have an optional **description** for the coach's own notes — for example, "Beginners group, week 3" or "Putting-focused tune-up before tournament weekend".
+
+### The five-section structure
+
+A practice session is organised into five fixed sections that follow a typical training arc:
+
+1. **Introduction** (5 min for both 60- and 90-minute sessions)
+2. **Warm-up** (10 min in a 60-minute session, 20 min in a 90-minute session)
+3. **Games, plays and challenges** (5 min in a 60-minute session, 10 min in a 90-minute session)
+4. **Technique** (the largest block; remaining time is allocated here)
+5. **Closing**
+
+Each section has its own time budget, which automatically adjusts based on the session length. The designer shows the duration on each section header so the user always knows how much time they are filling.
+
+### Adding items to a section
+
+Within each section, the user can add items in two ways:
+
+- **Add a generic exercise type** — for example, simply note that the _Introduction_ section will cover the _throwing order_, without picking a specific drill. This is useful for routine activities that do not need a written-up exercise.
+- **Add a specific exercise from the bank** — pick an exercise type (e.g. _Putting_), then pick one of the saved exercises that belong to that type. The exercise's name appears in the section's plan.
+
+The designer is smart about availability:
+
+- Once a generic type is added to a section, it is hidden from the dropdown so it cannot be added twice.
+- Once a specific exercise is added, it is removed from the available exercises list. If all exercises for a given type have been added, the type itself disappears from the menu.
+
+### The running time summary
+
+A sticky **summary panel** shows the total time allocated to the session as the user adds items. This makes it easy to see at a glance whether the session is filling up correctly relative to the chosen 60- or 90-minute target.
+
+### Validation and saving
+
+Before a session can be saved:
+
+- The session must have a name.
+- At least one item must have been selected in any section.
+
+If either is missing, the user sees a clear error message and the form does not submit.
+
+---
+
+## Feature 3 — The Practice Sessions Library
+
+Every session designed in the application is saved and listed on the _Practice Sessions_ page. From there the user can:
+
+- **Browse all saved sessions**, each shown with its name (or "Untitled session" if blank), creation date, total length in minutes, and the number of items it contains.
+- **See the full plan** of any session by clicking it. The detail view groups items by section, numbers them in order, and links specific exercises directly to their full instructions in the exercise bank.
+- **Edit a session** to change its name, description, length, sections or items.
+- **Delete a session**, with a confirmation dialog warning that the action is permanent.
+- **Open exercise details from within a session**, in a new tab, so the coach can read the instructions without losing their place in the plan.
+- **Return to the session list** with a clearly visible _Back to Practice Sessions_ link.
+
+A clear empty state appears when the user has not yet created any sessions, with a call-to-action button to design their first one.
+
+---
+
+## Other things the application does
+
+### Multilingual interface (Finnish and English)
+
+The whole interface — buttons, labels, error messages, exercise type names, section names — is fully translated. A language switcher lets the user toggle between Finnish ("FI") and English ("EN") at any time. New users default to Finnish, which matches the project's primary audience.
+
+### Rich content with YouTube videos
+
+Exercise content is written in a Markdown editor with extra controls for inserting YouTube videos. The user can paste either a full YouTube URL or just the 11-character video ID; the application validates the input and rejects invalid links with a helpful message. When the exercise is later viewed, the embedded videos are rendered as actual playable players inside the page.
+
+### Image uploads
+
+Each exercise can have an associated image. Users can upload common image formats (JPEG, PNG, GIF, WebP), see the current image when editing, and remove it through a confirmation dialog if they no longer want it associated with the exercise.
+
+### Friendly URLs (slugs)
+
+Both exercises and practice sessions have human-readable URLs based on their names. When two items would otherwise share the same URL, the application automatically adds a numeric suffix to keep each link unique. Slugs can also be regenerated in bulk via a maintenance script.
+
+### Bulk content import (for content managers)
+
+In addition to creating exercises one at a time through the user interface, the project ships with command-line tools for content managers:
+
+- A **web crawler** that can read training material from local HTML files, single web URLs, or a list of files/URLs, and convert it into a structured format (Markdown).
+- An **import script** that takes the parsed output and inserts it into the application's exercise bank in bulk, automatically generating slugs and validating the data.
+
+This is intended for situations where existing training material — for example, an external training website — needs to be brought into Harkkapankki without manual re-entry.
+
+---
+
+## Who the application is for
+
+- **Coaches** who want a single source of truth for the drills they teach, instead of a folder of PDFs or messy notes.
+- **Junior team trainers** who run regular structured sessions and want to vary the content week to week without rebuilding a plan from scratch every time.
+- **Players** who want to plan and follow their own self-coached practice sessions in a disciplined way.
+
+The interface is deliberately simple and visual: every screen explains what it is for, every action gives clear feedback, and the flow from "I have an idea for a session" to "here is the printable plan" is meant to take only a few minutes.
+
+---
+
+## What the application does _not_ (yet) do
+
+To set expectations honestly:
+
+- There is **no user account or login** — the application currently treats all data as shared. Anyone using the same instance sees the same exercise bank and the same saved sessions.
+- There is **no per-user permission system**, meaning anyone with access can create, edit, or delete any exercise or session.
+- There is **no calendar, attendance, or roster feature** — Harkkapankki plans sessions, but does not track who attended which session.
+- There is **no print-optimised view or PDF export** of a finished session — users can read the plan on screen and follow the links to individual exercises.
+
+These are noted only so that a non-technical reader has an accurate picture of the current scope.


### PR DESCRIPTION
## Summary

- Add a "Why Harkkapankki exists" section to `docs/Project summary.md` describing the underlying problem (recurring last-minute weekly planning chore), the personal goal, and the long-term plan to contribute the finished project to junnufriba.fi free of charge.
- Add `docs/18 - season planning feature plan.md` with the design plan for the upcoming season planning feature: schema additions (new `Season` table, `seasonId` and `scheduledAt` on `PracticeSession`), repository/route/form changes, phased rollout (Phase 1 ships the personal goal; Phase 4 is the auto-generation north star), and known risks (content shortage, no auth, DST handling).
- Documentation only — no code changes.

## Test plan

- [ ] Read `docs/Project summary.md` and confirm the new "Why" section accurately reflects the motivation and the planned junnufriba.fi handover.
- [ ] Read `docs/18 - season planning feature plan.md` and confirm the schema design, settled decisions, and phased rollout match expectations before any implementation begins.
- [ ] Confirm the cascade-behavior summary in doc 18 matches `prisma/schema.prisma` (`PracticeSessionSectionItem.exerciseId` already uses `onDelete: SetNull`).