### PR TITLE
PR A: Season schema and migration

### DIFF
--- a/docs/18 - season planning feature plan.md
+++ b/docs/18 - season planning feature plan.md
@@ -26,11 +26,45 @@ The schema is well-normalized and extending it for seasons is mostly additive.
 
 ## Decisions (settled)
 
-1. **Season is a first-class entity.** A new `Season` table will be added.
-2. **Sessions are scheduled to specific dates.** A `scheduledAt` (datetime) field will be added to `PracticeSession`. Nullable, so sessions without a planned date are valid (drafts).
-3. **Session lengths stay 60 / 90.** Generalising the duration model is deferred until a real need appears.
-4. **Existing standalone sessions are left as-is.** They get `seasonId = NULL` after migration. They are example data and don't need backfilling into a season.
-5. **Doc 16 is resolved.** Season planning UI builds on top of the resolved exercise type hierarchy work; there is no in-flux session-designer dependency.
+### Schema
+
+1. **Season is a first-class entity.** A new `Season` table is added.
+2. **Sessions are scheduled to specific dates.** A `scheduledAt` (`DateTime?`, UTC `timestamptz`) field is added to `PracticeSession`. Nullable: sessions without a date are drafts.
+3. **No `SeasonTranslation` table.** Season uses plain `name` and `description` columns, matching the pattern for user-created content (`Exercise`, `PracticeSession`). Season names are coach-typed and don't need translation.
+4. **`scheduledAt` stored as UTC `timestamptz`.** Helsinki wall-clock times are converted to UTC at write time via a TZ helper (`date-fns-tz` or equivalent). This is correct across DST transitions, which Finland's coaching season spans twice.
+5. **`defaultStartTime` is `String?` "HH:MM" with app-layer Zod validation.** Matches the codebase's "type + Zod" pattern (e.g., `sessionLength` is a plain `Int` with no DB CHECK constraint). End time in the UI is derived from `defaultStartTime + defaultDurationMin`.
+6. **`defaultDayOfWeek` is `Int?` using ISO 8601 (Monday=1, Sunday=7).** Documented inline on the column.
+7. **Defaults are copy-on-create.** When a session is created in a season, `sessionLength` (and other defaults) is copied from the season at write time. Editing the season's defaults later does not propagate to existing sessions.
+8. **Session lengths stay 60 / 90.** Generalising the duration model is deferred.
+9. **One composite index `@@index([seasonId, scheduledAt])` on `PracticeSession`.** Serves both "list sessions in this season ordered by date" and "filter by season alone." No standalone `scheduledAt` index.
+10. **`seasonId` is mutable in the schema** (free, nullable FK with `onDelete: SetNull`) **but not exposed in the session edit form for Phase 1.** Cross-season moves will be added when the user actually has multiple seasons.
+11. **Validation rules live at the app layer (Zod), not the DB.** Includes: `defaultDurationMin ∈ {60, 90}`; `endDate >= startDate` when both set; `defaultStartTime` matches `/^([01]\d|2[0-3]):[0-5]\d$/`; `defaultDayOfWeek ∈ 1..7`; `Season.name` required.
+
+### Auto-generation (pulled forward from Phase 4 to Phase 1)
+
+12. **Auto-generation runs at session-creation time** during the batch "Add sessions" flow. The manual `/practise-sessions/new` flow stays manual — no auto-gen there.
+13. **One item per section per session.** Each generated session has 5 items (one per fixed section).
+14. **Prefer specific exercises, fall back to type-only.** For each section, the algorithm picks an `Exercise` from a type linked to that section via `SectionExerciseType`. If no eligible `Exercise` is available, emit type-only.
+15. **Variety = no drill repeats within a rolling 3-session window, applied within-batch only.** When generating session N in a batch, exclude specific exercises used by sessions N-1 and N-2 in the same batch. Cross-batch repeats are accepted (can be upgraded later without schema change).
+16. **Sparse-bank fallback.** When fresh drills are exhausted, emit type-only items and surface a soft warning to the coach: "Putting bank is sparse, sessions 4–5 are type-only — consider adding more drills."
+
+### UX boundaries
+
+17. **Season detail page (`/seasons/$slug`)** shows: name + description + date range + defaults + Edit button at the top; a linear list of sessions ordered by `scheduledAt` ascending; a separate "Add sessions" route (not modal); list split into "Upcoming" and "Past" sections, with drafts (NULL `scheduledAt`) at the bottom of "Upcoming."
+18. **`/practise-sessions` global list filters to standalone sessions only** (`seasonId IS NULL`). Season-attached sessions are accessed via the season detail page. The list shows an info banner pointing to the Seasons surface.
+19. **Home page gains a new "Seasons" card** alongside the existing three. The "Design a practice session" card continues to lead to `/practise-sessions/new` and creates a standalone session by default.
+
+### "Add sessions" form
+
+20. **N-row inline-edit form** — user picks how many sessions (typically 1–10), the form renders N rows, each pre-filled with the season's defaults (date computed from `defaultDayOfWeek` rolling forward; start time and end time displayed inline). Coach can edit any row's date / start time / end time before submitting.
+21. **Date window starts at the later of (today, `season.startDate`).**
+22. **Past dates are hidden.** Backfilling past sessions uses the manual flow.
+23. **If the season has no `defaultDayOfWeek`, the action is blocked** with a message directing to the season settings page.
+
+### Existing-data handling
+
+24. **Existing standalone sessions are left as-is.** They get `seasonId = NULL` after migration. They are example data and don't need backfilling.
+25. **Doc 16 is resolved** (Phase 0 prerequisite). Season planning UI builds on top of the resolved exercise type hierarchy work.
 
 ## Schema changes
 
@@ -44,35 +78,40 @@ model Season {
   description         String?
   startDate           DateTime?
   endDate             DateTime?
-  defaultDayOfWeek    Int?     // 0-6, used to seed dates for new sessions
-  defaultStartTime    String?  // "17:00"
-  defaultDurationMin  Int?     // 60 or 90
+  defaultDayOfWeek    Int?     // ISO 8601: 1=Monday, 7=Sunday
+  defaultStartTime    String?  // wall-clock "HH:MM" in Europe/Helsinki, validated by Zod
+  defaultDurationMin  Int?     // 60 or 90, validated by Zod
   practiceSessions    PracticeSession[]
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
+
+  @@map("seasons")
 }
 ```
 
 Notes:
 
 - `endDate` is nullable because seasons rarely have a known end date in advance.
-- Defaults (`defaultDayOfWeek`, `defaultStartTime`, `defaultDurationMin`) are used when creating new sessions inside the season — each session can still override them.
-- `slug` follows the existing global-unique pattern (`slugify` + `makeUniqueSlug`).
+- Defaults (`defaultDayOfWeek`, `defaultStartTime`, `defaultDurationMin`) are used to seed sessions at creation time only. Editing them later does not propagate to existing sessions.
+- `slug` is unique within the `seasons` table; uses the existing `slugify` + `makeUniqueSlug` helpers.
 
 ### Additions to `PracticeSession`
 
 ```prisma
 seasonId    String?   @map("season_id")
 season      Season?   @relation(fields: [seasonId], references: [id], onDelete: SetNull)
-scheduledAt DateTime? @map("scheduled_at")
+scheduledAt DateTime? @map("scheduled_at")  // UTC timestamptz; converted from Helsinki wall-clock at write time
+
+@@index([seasonId, scheduledAt])
 ```
 
 Notes:
 
-- `seasonId` is nullable. Existing seasonless sessions remain valid.
-- `onDelete: SetNull` means deleting a season does not delete its sessions — they fall back to standalone. Safer default than cascade. Worth confirming when this is implemented.
-- `scheduledAt` is nullable. Sessions without a date are drafts and sort to the end of the season list.
-- **No `weekNumber` column.** Both calendar week and "session N of the season" can be derived from `scheduledAt` at view time (`getISOWeek(scheduledAt)` and `row_number() over (partition by seasonId order by scheduledAt)` respectively). Storing it would create an integrity problem when sessions are reordered or rescheduled.
+- `seasonId` is nullable. Existing seasonless sessions remain valid after migration.
+- `onDelete: SetNull` means deleting a season does not delete its sessions — they fall back to standalone.
+- `scheduledAt` is nullable. Drafts (NULL) sort to the bottom of the "Upcoming" list.
+- The composite index `@@index([seasonId, scheduledAt])` serves both "filter by season ordered by date" and "filter by season alone" via the leading column. No additional index on `scheduledAt` alone.
+- **No `weekNumber` column.** Both calendar week and "session N of the season" are derived from `scheduledAt` at view time (`getISOWeek(scheduledAt)` and `row_number() over (partition by seasonId order by scheduledAt)` respectively).
 
 ### Migration approach
 
@@ -86,29 +125,54 @@ Notes:
 
 - New: `app/repositories/season.server.ts` (CRUD).
 - New: `app/services/seasons.server.ts` (slug generation, date seeding from defaults, anything cross-cutting).
+- New: `app/services/sessionAutoGenerator.server.ts` (the auto-gen algorithm — pure picking logic given a DB context, easy to unit-test).
+- New: `app/utils/timezone.ts` (Helsinki ↔ UTC conversion helpers built on `date-fns-tz`).
 - Update: `app/repositories/practiceSession.server.ts` — accept optional `seasonId` filter and `scheduledAt` field on writes.
 
 ### Routes
 
 - `/seasons` — list of seasons (name, date range, session count).
-- `/seasons/new` — create-season form (name, description, optional dates, defaults).
-- `/seasons/$slug` — season overview: list of sessions ordered by `scheduledAt`, calendar view, "add sessions" action.
+- `/seasons/new` — create-season form. (When the user adopts the "create season + N initial sessions" combined flow, this route hosts that combined form.)
+- `/seasons/$slug` — season overview: metadata header, "Edit season" button, "Upcoming" + "Past" linear lists of sessions ordered by `scheduledAt`.
 - `/seasons/$slug/edit` — edit season metadata.
-- `/practise-sessions/new?seasonId=...` — existing form, prefilled with season defaults.
+- `/seasons/$slug/add-sessions` — N-row inline-edit form for adding sessions to an existing season.
+- `/practise-sessions` — **filtered to standalone sessions only** (`seasonId IS NULL`) with an info banner pointing to the Seasons surface.
+- `/practise-sessions/new` — gains an optional `seasonId` query param + a `scheduledAt` field. When invoked from the home card, both are absent and a standalone session is created.
 - `/practise-sessions/$slug` — existing detail view, with a back-link to its season when one is set.
 
 ### Forms
 
-- `PractiseSessionForm` gains an optional `scheduledAt` field and shows "part of season X" when `seasonId` is set.
 - New `SeasonForm` for create/edit.
+- New `AddSessionsForm` — N-row inline editor (count selector + N rows of date/start time/end time), shared between the season-creation combined flow and the existing-season add flow. End time is rendered derived from start time + duration; editing it inline reverse-computes duration.
+- `PractiseSessionForm` gains an optional `scheduledAt` field and shows a read-only "part of season X" badge when `seasonId` is set. Crucially, the form does **not** expose a season selector — `seasonId` is set at creation only and not editable for Phase 1.
 
-### "Add sessions" UX (Phase 1)
+### Auto-generation algorithm
 
-- Inside `/seasons/$slug`, an action to add multiple sessions at once.
-- Calendar UI showing the next ~20 occurrences of the season's `defaultDayOfWeek` starting from today.
-- Each occurrence is toggleable (click to add / remove a session for that date).
-- Each toggled-on date creates a `PracticeSession` with `scheduledAt` set, `seasonId` set, `sessionLength` = season's `defaultDurationMin`, and an empty section-item list ready to be filled in later.
-- The user can then click any session to design its content via the existing session designer.
+Pseudocode for the function called inside `/seasons/$slug/add-sessions` (and the season-creation combined flow):
+
+```
+generateProgrammeForBatch(season, rows):
+  newSessions = []
+  for i in 0..rows.length:
+    row = rows[i]
+    excludedExerciseIds = collect specific Exercise IDs from
+                          newSessions[max(0, i-2)..i-1]  // rolling 3-window, batch-only
+    items = []
+    for section in seasonSections:                       // 5 fixed sections
+      eligibleTypes = SectionExerciseType for this section
+      pickedExercise = first Exercise from eligibleTypes
+                       NOT in excludedExerciseIds, ordered by some randomization
+      if pickedExercise:
+        items.push({ section, exerciseType: pickedExercise.exerciseType,
+                     exerciseId: pickedExercise.id, order: section.order })
+      else:
+        items.push({ section, exerciseType: pick any eligibleType, order: section.order })
+        emit warning: "section X has no fresh drill; using type-only"
+    newSessions.push({ session: row, items })
+  return newSessions
+```
+
+All writes happen in a single transaction — either all sessions in the batch save, or none do.
 
 ### i18n
 
@@ -117,28 +181,45 @@ Notes:
 
 ### Slugs
 
-- Keep the existing global-unique pattern. Two seasons named "Week 1" become `week-1` and `week-1-2`.
-- Nested URLs (`/seasons/spring-2026/week-1`) are a future polish, not a Phase 1 concern.
+- `Season.slug` unique within the `seasons` table; uses the existing `slugify` + `makeUniqueSlug` helpers.
+- `PracticeSession.slug` continues to be unique within `practice_sessions`. No nested URLs in Phase 1.
 
 ## Phased rollout
 
 - **Phase 0** — _resolved._ Doc 16 (exercise type hierarchy) is done; the session designer UI is stable.
-- **Phase 1** — Season CRUD. Sessions can be attached to a season. `scheduledAt` per session. "Add sessions" calendar action. Session lists filterable by season. **This phase delivers the personal goal.**
+- **Phase 1** — Season CRUD; `scheduledAt` per session; "Add sessions" N-row form; **basic auto-generation** (one item per section, within-batch variety, type-only fallback when sparse); standalone vs season cleanup; home page nav. **This phase delivers the personal goal.**
 - **Phase 2** — Coverage stats. Read-only "what you've covered" view per season: which exercise types appear in which sessions, frequency, gaps. No suggestions yet — just visibility.
 - **Phase 3** — Smart suggestions. The system warns when a season is unbalanced ("no putting in last 3 sessions") or repeats too quickly. Coach decides what to do; nothing enforced.
-- **Phase 4** — Auto-generation. The system can propose a full season plan given a target group and a time window. **This is the north star.**
+- **Phase 4** — **Progression-aware auto-generation.** The system proposes a full season plan that introduces and builds on techniques in a sensible order. The Phase 1 auto-gen is the dumb baseline; Phase 4 layers progression intelligence on top. **This is the north star.**
+
+## Sequencing / PR plan
+
+Phase 1 ships across four PRs plus a UX-validation prototype:
+
+1. **PR A — Schema migration.** Adds the `Season` table, `seasonId` and `scheduledAt` columns on `PracticeSession`, the composite index. No app code beyond regenerated Prisma types.
+2. **Prototype (UI-only).** A render-only mock of the "create season + N initial sessions" combined form at `/prototypes/season-form`. Real interactivity (count selector adjusts rows, date/time pickers work, validation triggers) but **no DB writes** — submit hits a mock success state. Purpose: pin down form ergonomics and weed out bad ideas before backend code is written. Revise this doc with whatever the prototype reveals before continuing. The route is deleted in PR B (or one before) when the real implementation lands at `/seasons/new`.
+3. **PR B — Season CRUD.** Routes `/seasons`, `/seasons/new`, `/seasons/$slug`, `/seasons/$slug/edit`, delete. Uses the form shape validated by the prototype.
+4. **PR C — Add sessions + auto-gen.** Route `/seasons/$slug/add-sessions`, the auto-gen algorithm (with unit tests), atomic batch creation.
+5. **PR D — Standalone vs season cleanup + nav.** `/practise-sessions` filters to standalone-only; `PractiseSessionForm` gains `scheduledAt`; `/practise-sessions/new` accepts `seasonId` query param; home page gets the "Seasons" card.
+
+Between PR A and PR B, the schema is in `main` but no UI uses it — safe state, hidden by lack of nav links until PR D.
 
 ## Issues / blockers / risks
 
-1. **Content shortage.** The exercise bank covers a fraction of junnufriba.fi today. Variety/repetition logic in Phase 2+ will produce weak signals until coverage improves. Doesn't block Phase 1.
+1. **Content shortage.** The exercise bank covers a fraction of junnufriba.fi today. The Phase 1 auto-gen will hit type-only fallback often until the bank fills out. Mitigation: surface the soft warning ("sessions 4–5 are type-only") so the coach knows when adding more drills would help most. Doesn't block Phase 1.
 2. **No auth.** Fine for solo use. If junnufriba ever runs the project for multiple coaches, "my season" needs a User table — out of scope here, noted for the longer term.
-3. **Calendar/timezone correctness.** `scheduledAt` is a `DateTime` — needs care around timezone handling at form submission, especially for daylight-saving transitions in spring/autumn (the project's coaching season spans both DST changes in Finland). Worth a small explicit decision: store in UTC, render in Europe/Helsinki, accept user input as Helsinki-local.
+3. **Calendar/timezone correctness.** Settled: store `scheduledAt` as UTC `timestamptz`, render in Europe/Helsinki, accept user input as Helsinki-local. Adds a dependency on `date-fns-tz` (or equivalent). DST transitions (last Sunday of March, last Sunday of October) are correctly handled by always converting through the named zone, never through fixed UTC offsets.
+4. **Auto-gen quality is unproven until we use it.** The Phase 1 algorithm is intentionally simple (one item per section, within-batch variety only). Whether the generated sessions feel useful depends on bank coverage and the random-pick distribution. Mitigation: the prototype + first real PR-C usage will surface this fast; revise the algorithm before Phase 2.
+5. **Auto-gen needs unit tests.** The picking logic is a pure function given a DB context (eligible types, candidate exercises, exclusion set). Phase 1's PR-C should ship with unit tests covering: one item per section, exclusion-set respected, type-only fallback when no fresh drill, deterministic behavior under a seeded RNG.
 
 ## Open implementation details to settle later
 
 These are not schema or design decisions — they're UX/UI choices that don't change the database and can be settled when Phase 1 is being built:
 
-- Visual treatment of the calendar in "Add sessions" (grid? list? inline calendar component?).
-- Should past sessions be visually de-emphasised in the season overview?
-- What does the season list look like when there are no seasons yet (empty state)?
-- Should deleting a season prompt about its sessions ("convert to standalone" vs "delete with season")? — `onDelete: SetNull` makes "convert to standalone" the default behavior; the prompt would just confirm.
+- Specific date and time picker components (decided during the prototype).
+- Per-session "Regenerate programme" button — deferred to Phase 1.5 or later. Phase 1 has no regeneration; if a generated session is bad, you delete and re-create.
+- `/seasons` list page sort order, empty-state copy, and CTA placement.
+- Edit season form layout (assumed mirror of create form).
+- Delete season UX: confirmation dialog wording. The `onDelete: SetNull` behavior makes "sessions detach to standalone" the default; the dialog just confirms.
+- Visual treatment of past vs upcoming sessions on the season detail page (de-emphasis, separator styling).
+- i18n keys for new copy (mechanical; FI + EN).

--- a/prisma/migrations/20260505043119_add_seasons/migration.sql
+++ b/prisma/migrations/20260505043119_add_seasons/migration.sql
@@ -1,0 +1,29 @@
+-- AlterTable
+ALTER TABLE "practice_sessions" ADD COLUMN     "scheduled_at" TIMESTAMP(3),
+ADD COLUMN     "season_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "seasons" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "start_date" TIMESTAMP(3),
+    "end_date" TIMESTAMP(3),
+    "default_day_of_week" INTEGER,
+    "default_start_time" TEXT,
+    "default_duration_min" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "seasons_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "seasons_slug_key" ON "seasons"("slug");
+
+-- CreateIndex
+CREATE INDEX "practice_sessions_season_id_scheduled_at_idx" ON "practice_sessions"("season_id", "scheduled_at");
+
+-- AddForeignKey
+ALTER TABLE "practice_sessions" ADD CONSTRAINT "practice_sessions_season_id_fkey" FOREIGN KEY ("season_id") REFERENCES "seasons"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,114 +8,114 @@ datasource db {
 }
 
 model ExerciseType {
-  id          String        @id @default(uuid())
-  slug        String        @unique // computer-friendly name, e.g. "technique", "backhand"
-  parentId    String?       // null for root level types
-  parent      ExerciseType? @relation("ExerciseTypeHierarchy", fields: [parentId], references: [id])
-  children    ExerciseType[] @relation("ExerciseTypeHierarchy")
-  translations ExerciseTypeTranslation[]
-  exercises    Exercise[]
-  sectionLinks SectionExerciseType[]
+  id               String                       @id @default(uuid())
+  slug             String                       @unique // computer-friendly name, e.g. "technique", "backhand"
+  parentId         String? // null for root level types
+  parent           ExerciseType?                @relation("ExerciseTypeHierarchy", fields: [parentId], references: [id])
+  children         ExerciseType[]               @relation("ExerciseTypeHierarchy")
+  translations     ExerciseTypeTranslation[]
+  exercises        Exercise[]
+  sectionLinks     SectionExerciseType[]
   groupMemberships ExerciseTypeGroupMember[]
-  sessionItems PracticeSessionSectionItem[]
-  createdAt   DateTime     @default(now()) @map("created_at")
-  updatedAt   DateTime     @updatedAt @map("updated_at")
+  sessionItems     PracticeSessionSectionItem[]
+  createdAt        DateTime                     @default(now()) @map("created_at")
+  updatedAt        DateTime                     @updatedAt @map("updated_at")
 
-  @@map("exercise_types")
   @@index([parentId])
+  @@map("exercise_types")
 }
 
 model ExerciseTypeTranslation {
-  id            String       @id @default(uuid())
-  exerciseType  ExerciseType @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
-  exerciseTypeId String      @map("exercise_type_id")
-  language      String       // e.g. "fi", "en", "sv"
-  name          String       // translated name
-  description   String?      // optional description in the given language
-  createdAt     DateTime     @default(now()) @map("created_at")
-  updatedAt     DateTime     @updatedAt @map("updated_at")
+  id             String       @id @default(uuid())
+  exerciseType   ExerciseType @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
+  exerciseTypeId String       @map("exercise_type_id")
+  language       String // e.g. "fi", "en", "sv"
+  name           String // translated name
+  description    String? // optional description in the given language
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
 
-  @@map("exercise_type_translations")
   @@unique([exerciseTypeId, language])
   @@index([language])
+  @@map("exercise_type_translations")
 }
 
 model Exercise {
-  id            String       @id @default(uuid())
-  slug          String       @unique
-  name          String
-  description   String?
-  content       String
-  image         String?      // path to uploaded image
-  youtubeVideo  String?     @map("youtube_video")
-  duration      Int
-  exerciseType  ExerciseType @relation(fields: [exerciseTypeId], references: [id])
-  exerciseTypeId String      @map("exercise_type_id")
-  createdAt     DateTime    @default(now()) @map("created_at")
-  updatedAt     DateTime    @updatedAt @map("updated_at")
+  id             String       @id @default(uuid())
+  slug           String       @unique
+  name           String
+  description    String?
+  content        String
+  image          String? // path to uploaded image
+  youtubeVideo   String?      @map("youtube_video")
+  duration       Int
+  exerciseType   ExerciseType @relation(fields: [exerciseTypeId], references: [id])
+  exerciseTypeId String       @map("exercise_type_id")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
 
-  sessionItems  PracticeSessionSectionItem[]
+  sessionItems PracticeSessionSectionItem[]
 
-  @@map("exercises")
   @@index([exerciseTypeId])
+  @@map("exercises")
 }
 
 model ExerciseTypeGroup {
-  id          String   @id @default(uuid())
-  slug        String   @unique
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  id        String   @id @default(uuid())
+  slug      String   @unique
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
-  translations    ExerciseTypeGroupTranslation[]
-  exerciseTypes   ExerciseTypeGroupMember[]
+  translations  ExerciseTypeGroupTranslation[]
+  exerciseTypes ExerciseTypeGroupMember[]
 
   @@map("exercise_type_groups")
 }
 
 model ExerciseTypeGroupTranslation {
-  id          String             @id @default(uuid())
-  group       ExerciseTypeGroup  @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  groupId     String             @map("group_id")
+  id          String            @id @default(uuid())
+  group       ExerciseTypeGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId     String            @map("group_id")
   language    String
   name        String
   description String?
-  createdAt   DateTime           @default(now()) @map("created_at")
-  updatedAt   DateTime           @updatedAt @map("updated_at")
+  createdAt   DateTime          @default(now()) @map("created_at")
+  updatedAt   DateTime          @updatedAt @map("updated_at")
 
-  @@map("exercise_type_group_translations")
   @@unique([groupId, language])
   @@index([language])
+  @@map("exercise_type_group_translations")
 }
 
 model ExerciseTypeGroupMember {
-  id              String            @id @default(uuid())
-  group           ExerciseTypeGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  groupId         String            @map("group_id")
-  exerciseType    ExerciseType      @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
-  exerciseTypeId  String            @map("exercise_type_id")
-  createdAt       DateTime          @default(now()) @map("created_at")
-  updatedAt       DateTime          @updatedAt @map("updated_at")
+  id             String            @id @default(uuid())
+  group          ExerciseTypeGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId        String            @map("group_id")
+  exerciseType   ExerciseType      @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
+  exerciseTypeId String            @map("exercise_type_id")
+  createdAt      DateTime          @default(now()) @map("created_at")
+  updatedAt      DateTime          @updatedAt @map("updated_at")
 
-  @@map("exercise_type_group_members")
   @@unique([groupId, exerciseTypeId])
   @@index([groupId])
   @@index([exerciseTypeId])
+  @@map("exercise_type_group_members")
 }
 
 model Section {
-  id          String   @id @default(uuid())
-  slug        String   @unique
-  order       Int
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  id        String   @id @default(uuid())
+  slug      String   @unique
+  order     Int
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
-  translations        SectionTranslation[]
-  durationConfigs     SectionDurationConfig[]
-  exerciseTypeLinks   SectionExerciseType[]
-  sessionItems        PracticeSessionSectionItem[]
+  translations      SectionTranslation[]
+  durationConfigs   SectionDurationConfig[]
+  exerciseTypeLinks SectionExerciseType[]
+  sessionItems      PracticeSessionSectionItem[]
 
-  @@map("sections")
   @@index([order])
+  @@map("sections")
 }
 
 model SectionTranslation {
@@ -128,51 +128,73 @@ model SectionTranslation {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  @@map("section_translations")
   @@unique([sectionId, language])
   @@index([language])
+  @@map("section_translations")
 }
 
 model SectionDurationConfig {
-  id              String   @id @default(uuid())
-  section         Section  @relation(fields: [sectionId], references: [id], onDelete: Cascade)
-  sectionId       String   @map("section_id")
-  sessionLength   Int      @map("session_length")
-  duration        Int
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt @map("updated_at")
-
-  @@map("section_duration_configs")
-  @@unique([sectionId, sessionLength])
-  @@index([sessionLength])
-}
-
-model SectionExerciseType {
-  id              String       @id @default(uuid())
-  section         Section      @relation(fields: [sectionId], references: [id], onDelete: Cascade)
-  sectionId       String       @map("section_id")
-  exerciseType    ExerciseType @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
-  exerciseTypeId  String       @map("exercise_type_id")
-  createdAt       DateTime     @default(now()) @map("created_at")
-  updatedAt       DateTime     @updatedAt @map("updated_at")
-
-  @@map("section_exercise_types")
-  @@unique([sectionId, exerciseTypeId])
-  @@index([sectionId])
-  @@index([exerciseTypeId])
-}
-
-model PracticeSession {
   id            String   @id @default(uuid())
-  slug          String   @unique
-  name          String?
-  description   String?  @db.Text
+  section       Section  @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  sectionId     String   @map("section_id")
   sessionLength Int      @map("session_length")
+  duration      Int
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
 
-  sectionItems  PracticeSessionSectionItem[]
+  @@unique([sectionId, sessionLength])
+  @@index([sessionLength])
+  @@map("section_duration_configs")
+}
 
+model SectionExerciseType {
+  id             String       @id @default(uuid())
+  section        Section      @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  sectionId      String       @map("section_id")
+  exerciseType   ExerciseType @relation(fields: [exerciseTypeId], references: [id], onDelete: Cascade)
+  exerciseTypeId String       @map("exercise_type_id")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+
+  @@unique([sectionId, exerciseTypeId])
+  @@index([sectionId])
+  @@index([exerciseTypeId])
+  @@map("section_exercise_types")
+}
+
+model Season {
+  id                 String    @id @default(uuid())
+  slug               String    @unique
+  name               String
+  description        String?   @db.Text
+  startDate          DateTime? @map("start_date")
+  endDate            DateTime? @map("end_date")
+  defaultDayOfWeek   Int?      @map("default_day_of_week") // ISO 8601: 1=Monday, 7=Sunday
+  defaultStartTime   String?   @map("default_start_time") // wall-clock "HH:MM" in Europe/Helsinki, validated by Zod
+  defaultDurationMin Int?      @map("default_duration_min") // 60 or 90, validated by Zod
+  createdAt          DateTime  @default(now()) @map("created_at")
+  updatedAt          DateTime  @updatedAt @map("updated_at")
+
+  practiceSessions PracticeSession[]
+
+  @@map("seasons")
+}
+
+model PracticeSession {
+  id            String    @id @default(uuid())
+  slug          String    @unique
+  name          String?
+  description   String?   @db.Text
+  sessionLength Int       @map("session_length")
+  seasonId      String?   @map("season_id")
+  season        Season?   @relation(fields: [seasonId], references: [id], onDelete: SetNull)
+  scheduledAt   DateTime? @map("scheduled_at")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
+
+  sectionItems PracticeSessionSectionItem[]
+
+  @@index([seasonId, scheduledAt])
   @@map("practice_sessions")
 }
 
@@ -190,10 +212,10 @@ model PracticeSessionSectionItem {
   createdAt         DateTime        @default(now()) @map("created_at")
   updatedAt         DateTime        @updatedAt @map("updated_at")
 
-  @@map("practice_session_section_items")
   @@unique([practiceSessionId, sectionId, exerciseTypeId, exerciseId])
   @@index([practiceSessionId])
   @@index([sectionId])
   @@index([exerciseTypeId])
   @@index([exerciseId])
+  @@map("practice_session_section_items")
 }


### PR DESCRIPTION
## Summary

First of four PRs implementing Phase 1 of the season planning feature (per `docs/18`). This PR is **schema-only** — no app code changes beyond Prisma client regeneration.

### Schema changes

- New `seasons` table with `name`, `description`, optional date range, and optional defaults (`defaultDayOfWeek` ISO 8601 1-7, `defaultStartTime` wall-clock `"HH:MM"`, `defaultDurationMin` 60 or 90).
- Added `season_id` (nullable FK with `ON DELETE SET NULL`) and `scheduled_at` (nullable timestamp) columns to `practice_sessions`.
- Added composite index on `practice_sessions(season_id, scheduled_at)` to serve the dominant query "list sessions in this season ordered by date" (and "filter by season alone" via the leading column).

### Behavior on existing data

- Existing `practice_sessions` rows get `season_id = NULL` and `scheduled_at = NULL`. They remain valid as standalone sessions; no backfill needed.
- Deleting a `Season` detaches its sessions to standalone (no cascade).

### Doc refinement (first commit)

Doc 18 was substantially refined after a design-review grill. The "Decisions (settled)" section was expanded from 5 to 25 items grouped by theme. Basic auto-generation was pulled forward from Phase 4 to Phase 1 (without progression awareness). The PR sequence is now: this schema PR → UI-only prototype at `/prototypes/season-form` → 4 implementation PRs.

## Test plan

- [ ] Confirm migration applies cleanly: `npx prisma migrate dev` — ✅ already applied locally during PR construction.
- [ ] Confirm migration applies cleanly on a fresh DB: `npx prisma migrate reset` (destructive — only run on dev).
- [ ] Confirm `npm run lint` passes — ✅ verified.
- [ ] Confirm `npx tsc --noEmit` passes — ✅ verified.
- [ ] Read `docs/18` to confirm the refined plan still matches expectations before subsequent PRs.

## What's next

After this lands, the next step is the UI-only prototype at `/prototypes/season-form` to pin down the form ergonomics before any backend work in PR B.