### PR TITLE
Add /seasons/$slug/add-sessions with auto-gen (PR C)

### DIFF
--- a/app/components/AddSessionsForm.tsx
+++ b/app/components/AddSessionsForm.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react';
+import { Form, Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import { Button } from '~/components/Button';
+
+const MIN_SESSIONS = 1;
+const MAX_SESSIONS = 20;
+const DEFAULT_TIME_FALLBACK = '17:00';
+const DEFAULT_DURATION_FALLBACK = 90;
+const DEFAULT_DAY_OF_WEEK_FALLBACK = 3;
+
+export type SessionRow = {
+  id: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+};
+
+type SeasonDefaults = {
+  startDate: Date | string | null;
+  endDate: Date | string | null;
+  defaultDayOfWeek: number | null;
+  defaultStartTime: string | null;
+  defaultDurationMin: number | null;
+};
+
+type AddSessionsFormProps = {
+  season: SeasonDefaults;
+  cancelHref: string;
+  submitText: string;
+  initialCount?: number;
+  errors?: Record<string, string>;
+};
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function formatDate(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function addMinutes(timeStr: string, minutes: number): string {
+  const [h, m] = timeStr.split(':').map(Number);
+  const total = h * 60 + m + minutes;
+  const newH = Math.floor((total / 60) % 24);
+  const newM = total % 60;
+  return `${pad(newH)}:${pad(newM)}`;
+}
+
+function diffMinutes(startTime: string, endTime: string): number {
+  const [sh, sm] = startTime.split(':').map(Number);
+  const [eh, em] = endTime.split(':').map(Number);
+  return eh * 60 + em - (sh * 60 + sm);
+}
+
+function nextOccurrenceOfWeekday(fromDate: Date, isoDayOfWeek: number): Date {
+  const jsTarget = isoDayOfWeek === 7 ? 0 : isoDayOfWeek;
+  const result = new Date(fromDate);
+  const diff = (jsTarget - result.getDay() + 7) % 7;
+  result.setDate(result.getDate() + diff);
+  return result;
+}
+
+function buildInitialRows(count: number, season: SeasonDefaults): SessionRow[] {
+  const startTime = season.defaultStartTime || DEFAULT_TIME_FALLBACK;
+  const duration = season.defaultDurationMin || DEFAULT_DURATION_FALLBACK;
+  const dayOfWeek = season.defaultDayOfWeek || DEFAULT_DAY_OF_WEEK_FALLBACK;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const seasonStart = season.startDate ? new Date(season.startDate) : null;
+  const fromDate = seasonStart && seasonStart > today ? seasonStart : today;
+  let cursor = nextOccurrenceOfWeekday(fromDate, dayOfWeek);
+
+  const rows: SessionRow[] = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: crypto.randomUUID(),
+      date: formatDate(cursor),
+      startTime,
+      endTime: addMinutes(startTime, duration),
+    });
+    cursor = new Date(cursor);
+    cursor.setDate(cursor.getDate() + 7);
+  }
+  return rows;
+}
+
+export default function AddSessionsForm({
+  season,
+  cancelHref,
+  submitText,
+  initialCount = 3,
+  errors,
+}: AddSessionsFormProps) {
+  const { t } = useTranslation();
+  const initialRows = buildInitialRows(initialCount, season);
+  const [count, setCount] = useState(initialCount);
+  const [rows, setRows] = useState<SessionRow[]>(initialRows);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const handleCountChange = (raw: string) => {
+    const next = Number(raw);
+    if (!Number.isFinite(next) || next < MIN_SESSIONS || next > MAX_SESSIONS) return;
+    setCount(next);
+    if (next > rows.length) {
+      const additional = next - rows.length;
+      const lastRow = rows[rows.length - 1];
+      const baseDate = lastRow ? new Date(lastRow.date) : new Date();
+      const startTime = lastRow?.startTime || season.defaultStartTime || DEFAULT_TIME_FALLBACK;
+      const duration = lastRow
+        ? diffMinutes(lastRow.startTime, lastRow.endTime)
+        : season.defaultDurationMin || DEFAULT_DURATION_FALLBACK;
+      const newRows: SessionRow[] = [];
+      for (let i = 1; i <= additional; i++) {
+        const d = new Date(baseDate);
+        d.setDate(d.getDate() + 7 * i);
+        newRows.push({
+          id: crypto.randomUUID(),
+          date: formatDate(d),
+          startTime,
+          endTime: addMinutes(startTime, duration > 0 ? duration : DEFAULT_DURATION_FALLBACK),
+        });
+      }
+      setRows([...rows, ...newRows]);
+    } else if (next < rows.length) {
+      setRows(rows.slice(0, next));
+    }
+  };
+
+  const handleRegenerate = () => {
+    setRows(buildInitialRows(count, season));
+  };
+
+  const updateRow = (id: string, updates: Partial<SessionRow>) => {
+    setRows(prev => prev.map(r => (r.id === id ? { ...r, ...updates } : r)));
+  };
+
+  const handleStartTimeChange = (id: string, newStart: string) => {
+    setRows(prev =>
+      prev.map(r => {
+        if (r.id !== id) return r;
+        const duration = diffMinutes(r.startTime, r.endTime);
+        return {
+          ...r,
+          startTime: newStart,
+          endTime: addMinutes(
+            newStart,
+            duration > 0 ? duration : season.defaultDurationMin || DEFAULT_DURATION_FALLBACK
+          ),
+        };
+      })
+    );
+  };
+
+  const removeRow = (id: string) => {
+    setRows(prev => {
+      const next = prev.filter(r => r.id !== id);
+      setCount(next.length);
+      return next;
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (rows.length === 0) {
+      e.preventDefault();
+      setClientError(t('addSessions.atLeastOne'));
+      return;
+    }
+    for (const row of rows) {
+      if (!row.date || !row.startTime || !row.endTime) {
+        e.preventDefault();
+        setClientError(t('addSessions.allFieldsRequired'));
+        return;
+      }
+      if (diffMinutes(row.startTime, row.endTime) <= 0) {
+        e.preventDefault();
+        setClientError(t('addSessions.endAfterStart'));
+        return;
+      }
+    }
+    setClientError(null);
+  };
+
+  return (
+    <Form method="post" onSubmit={handleSubmit} noValidate>
+      <fieldset className="mb-6 rounded border border-gray-200 p-4">
+        <legend className="px-2 text-lg font-semibold">{t('addSessions.section')}</legend>
+
+        <div className="mb-4 flex flex-wrap items-end gap-4">
+          <div>
+            <label htmlFor="sessionCount" className="mb-1 block text-sm font-medium">
+              {t('addSessions.howMany')}
+            </label>
+            <input
+              type="number"
+              id="sessionCount"
+              min={MIN_SESSIONS}
+              max={MAX_SESSIONS}
+              value={count}
+              onChange={e => handleCountChange(e.target.value)}
+              className="w-24 rounded border border-gray-300 px-3 py-2"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleRegenerate}
+            className="rounded border border-gray-300 px-3 py-2 text-sm hover:bg-gray-50"
+          >
+            {t('addSessions.regenerate')}
+          </button>
+        </div>
+
+        {rows.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left font-medium text-gray-700">
+                  <th className="py-2 pr-4">#</th>
+                  <th className="py-2 pr-4">{t('addSessions.date')}</th>
+                  <th className="py-2 pr-4">{t('addSessions.startTime')}</th>
+                  <th className="py-2 pr-4">{t('addSessions.endTime')}</th>
+                  <th className="py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, idx) => (
+                  <tr key={row.id} className="border-b">
+                    <td className="py-2 pr-4 text-gray-500">{idx + 1}</td>
+                    <td className="py-2 pr-4">
+                      <input
+                        type="date"
+                        value={row.date}
+                        onChange={e => updateRow(row.id, { date: e.target.value })}
+                        className="rounded border border-gray-300 px-2 py-1"
+                        aria-label={t('addSessions.rowDate', { index: idx + 1 })}
+                      />
+                    </td>
+                    <td className="py-2 pr-4">
+                      <input
+                        type="time"
+                        value={row.startTime}
+                        onChange={e => handleStartTimeChange(row.id, e.target.value)}
+                        className="rounded border border-gray-300 px-2 py-1"
+                        aria-label={t('addSessions.rowStartTime', { index: idx + 1 })}
+                      />
+                    </td>
+                    <td className="py-2 pr-4">
+                      <input
+                        type="time"
+                        value={row.endTime}
+                        onChange={e => updateRow(row.id, { endTime: e.target.value })}
+                        className="rounded border border-gray-300 px-2 py-1"
+                        aria-label={t('addSessions.rowEndTime', { index: idx + 1 })}
+                      />
+                    </td>
+                    <td className="py-2">
+                      <button
+                        type="button"
+                        onClick={() => removeRow(row.id)}
+                        className="px-2 py-1 text-sm text-red-600 hover:text-red-700"
+                        aria-label={t('addSessions.removeRow', { index: idx + 1 })}
+                      >
+                        {t('addSessions.remove')}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-600">{t('addSessions.empty')}</p>
+        )}
+
+        {clientError && <p className="mt-2 text-sm text-red-600">{clientError}</p>}
+        {errors?.rows && <p className="mt-2 text-sm text-red-600">{errors.rows}</p>}
+      </fieldset>
+
+      <input type="hidden" name="rows" value={JSON.stringify(rows)} />
+
+      <div className="flex justify-end gap-3">
+        <Link
+          to={cancelHref}
+          className="inline-flex items-center rounded border border-gray-300 px-4 py-2 text-sm font-medium hover:bg-gray-50"
+        >
+          {t('common.cancel')}
+        </Link>
+        <Button type="submit">{submitText}</Button>
+      </div>
+    </Form>
+  );
+}

--- a/app/pages/AddSessionsPage.tsx
+++ b/app/pages/AddSessionsPage.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import AddSessionsForm from '~/components/AddSessionsForm';
+
+type SeasonDefaults = {
+  slug: string;
+  name: string;
+  startDate: Date | string | null;
+  endDate: Date | string | null;
+  defaultDayOfWeek: number | null;
+  defaultStartTime: string | null;
+  defaultDurationMin: number | null;
+};
+
+type AddSessionsPageProps = {
+  season: SeasonDefaults;
+  actionData?: {
+    errors?: Record<string, string>;
+  };
+};
+
+export default function AddSessionsPage({ season, actionData }: AddSessionsPageProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <div className="mb-4">
+        <Link
+          to={`/seasons/${season.slug}`}
+          className="text-blue-600 hover:text-blue-800 inline-flex items-center"
+        >
+          {t('seasons.backToSeasons')}
+        </Link>
+      </div>
+      <h1 className="mb-2 text-3xl font-bold">{t('addSessions.title')}</h1>
+      <p className="mb-6 text-gray-600">{t('addSessions.subtitle', { season: season.name })}</p>
+
+      <AddSessionsForm
+        season={season}
+        cancelHref={`/seasons/${season.slug}`}
+        submitText={t('addSessions.submit')}
+        errors={actionData?.errors}
+      />
+    </div>
+  );
+}

--- a/app/pages/SeasonDetailPage.tsx
+++ b/app/pages/SeasonDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Form, Link, useNavigation } from 'react-router';
+import { Form, Link, useNavigation, useSearchParams } from 'react-router';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '~/components/Button';
@@ -33,8 +33,10 @@ type SeasonDetailPageProps = {
 export default function SeasonDetailPage({ season }: SeasonDetailPageProps) {
   const { t } = useTranslation();
   const navigation = useNavigation();
+  const [searchParams] = useSearchParams();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
+  const warningCount = Number(searchParams.get('warnings') ?? '0');
   const isDeleting = navigation.state !== 'idle' && navigation.formData?.get('intent') === 'delete';
 
   const formatDate = (value: Date | string | null) =>
@@ -107,8 +109,25 @@ export default function SeasonDetailPage({ season }: SeasonDetailPageProps) {
         </div>
       </dl>
 
+      {warningCount > 0 && (
+        <div
+          role="status"
+          className="mb-4 rounded border border-amber-500 bg-amber-50 p-4 text-amber-900"
+        >
+          {t('addSessions.warningBanner', { count: warningCount })}
+        </div>
+      )}
+
       <div>
-        <h2 className="text-xl font-semibold mb-3">{t('seasons.practiceSessions')}</h2>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">{t('seasons.practiceSessions')}</h2>
+          <Link
+            to={`/seasons/${season.slug}/add-sessions`}
+            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            {t('addSessions.cta')}
+          </Link>
+        </div>
         {season.practiceSessions.length === 0 ? (
           <p className="text-gray-500">{t('seasons.noPracticeSessions')}</p>
         ) : (

--- a/app/repositories/practiceSession.server.ts
+++ b/app/repositories/practiceSession.server.ts
@@ -1,16 +1,21 @@
+import type { Prisma } from '@prisma/client';
 import { db } from '~/utils/db.server';
+
+type SessionSectionItemInput = {
+  sectionId: string;
+  exerciseTypeId: string;
+  exerciseId?: string | null;
+  order: number;
+};
 
 type CreatePracticeSessionData = {
   slug: string;
   name?: string;
   description?: string;
   sessionLength: number;
-  sectionItems: Array<{
-    sectionId: string;
-    exerciseTypeId: string;
-    exerciseId?: string | null;
-    order: number;
-  }>;
+  seasonId?: string | null;
+  scheduledAt?: Date | null;
+  sectionItems: SessionSectionItemInput[];
 };
 
 export async function createPracticeSession(data: CreatePracticeSessionData) {
@@ -20,6 +25,8 @@ export async function createPracticeSession(data: CreatePracticeSessionData) {
       name: data.name || null,
       description: data.description || null,
       sessionLength: data.sessionLength,
+      seasonId: data.seasonId ?? null,
+      scheduledAt: data.scheduledAt ?? null,
       sectionItems: {
         create: data.sectionItems,
       },
@@ -38,6 +45,25 @@ export async function createPracticeSession(data: CreatePracticeSessionData) {
             },
           },
         },
+      },
+    },
+  });
+}
+
+export async function createPracticeSessionTx(
+  tx: Prisma.TransactionClient,
+  data: CreatePracticeSessionData
+) {
+  return tx.practiceSession.create({
+    data: {
+      slug: data.slug,
+      name: data.name || null,
+      description: data.description || null,
+      sessionLength: data.sessionLength,
+      seasonId: data.seasonId ?? null,
+      scheduledAt: data.scheduledAt ?? null,
+      sectionItems: {
+        create: data.sectionItems,
       },
     },
   });
@@ -177,6 +203,19 @@ export async function findPracticeSessionsBySlugs(slugs: string[]) {
     where: {
       slug: {
         in: slugs,
+      },
+    },
+    select: {
+      slug: true,
+    },
+  });
+}
+
+export async function findPracticeSessionsBySlugPrefix(prefix: string) {
+  return db.practiceSession.findMany({
+    where: {
+      slug: {
+        startsWith: prefix,
       },
     },
     select: {

--- a/app/routes/seasons.$slug_.add-sessions.tsx
+++ b/app/routes/seasons.$slug_.add-sessions.tsx
@@ -1,0 +1,62 @@
+import {
+  data,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from 'react-router';
+import { useActionData, useLoaderData } from 'react-router';
+import AddSessionsPage from '~/pages/AddSessionsPage';
+import { addSessionsSchema } from '~/schemas/addSessions';
+import { createSessionsForSeason, fetchAddSessionsContext } from '~/services/seasons.server';
+import { getDefaultLocale } from '~/utils/locale.server';
+import { parseData } from '~/utils/validation';
+
+export const meta: MetaFunction<typeof loader> = ({ data: loaderData }) => {
+  if (!loaderData?.season) {
+    return [{ title: 'Season Not Found - Harkkapankki' }];
+  }
+  return [{ title: `Add sessions to ${loaderData.season.name} - Harkkapankki` }];
+};
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const ctx = await fetchAddSessionsContext(params.slug!, getDefaultLocale());
+  if (!ctx) {
+    throw new Response('Season not found', { status: 404 });
+  }
+  return { season: ctx.season };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const ctx = await fetchAddSessionsContext(params.slug!, getDefaultLocale());
+  if (!ctx) {
+    throw new Response('Season not found', { status: 404 });
+  }
+
+  const formData = await request.formData();
+  const formDataObj = Object.fromEntries(formData);
+
+  const result = parseData(addSessionsSchema, formDataObj);
+  if (!result.success) {
+    return data({ errors: result.errors }, { status: 400 });
+  }
+
+  const { warnings } = await createSessionsForSeason({
+    season: { id: ctx.season.id, slug: ctx.season.slug },
+    sections: ctx.sections,
+    rows: result.data.rows,
+  });
+
+  const params2 = new URLSearchParams();
+  if (warnings.length > 0) {
+    params2.set('warnings', String(warnings.length));
+  }
+  const query = params2.toString();
+  return redirect(`/seasons/${ctx.season.slug}${query ? `?${query}` : ''}`);
+}
+
+export default function AddSessionsRoute() {
+  const { season } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  return <AddSessionsPage season={season} actionData={actionData} />;
+}

--- a/app/schemas/addSessions.ts
+++ b/app/schemas/addSessions.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+const rowSchema = z
+  .object({
+    date: z.string().regex(DATE_PATTERN, 'Invalid date'),
+    startTime: z.string().regex(TIME_PATTERN, 'Invalid start time'),
+    endTime: z.string().regex(TIME_PATTERN, 'Invalid end time'),
+  })
+  .refine(
+    row => {
+      const [sh, sm] = row.startTime.split(':').map(Number);
+      const [eh, em] = row.endTime.split(':').map(Number);
+      return eh * 60 + em - (sh * 60 + sm) >= 30;
+    },
+    { message: 'End time must be at least 30 minutes after start time' }
+  );
+
+export const addSessionsSchema = z.object({
+  rows: z
+    .string()
+    .min(1, 'rows is required')
+    .transform((value, ctx) => {
+      try {
+        return JSON.parse(value) as unknown;
+      } catch {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Invalid rows payload' });
+        return z.NEVER;
+      }
+    })
+    .pipe(
+      z
+        .array(rowSchema)
+        .min(1, 'At least one session is required')
+        .max(20, 'Maximum 20 sessions per batch')
+    ),
+});
+
+export type AddSessionsRow = z.infer<typeof rowSchema>;
+export type AddSessionsFormData = z.infer<typeof addSessionsSchema>;

--- a/app/services/seasons.server.ts
+++ b/app/services/seasons.server.ts
@@ -1,6 +1,18 @@
 import * as seasonRepo from '~/repositories/season.server';
+import * as sectionRepo from '~/repositories/section.server';
+import {
+  createPracticeSessionTx,
+  findPracticeSessionsBySlugPrefix,
+} from '~/repositories/practiceSession.server';
+import { db } from '~/utils/db.server';
 import type { SeasonFormData } from '~/schemas/season';
-import { slugify, makeUniqueSlug } from '~/utils/slugify';
+import type { AddSessionsRow } from '~/schemas/addSessions';
+import { makeUniqueSlug, slugify } from '~/utils/slugify';
+import { helsinkiWallClockToUtc } from '~/utils/timezone';
+import {
+  generateProgrammeForBatch,
+  type GeneratorWarning,
+} from '~/services/sessionAutoGenerator.server';
 
 export async function createSeason(input: SeasonFormData) {
   const baseSlug = slugify(input.name);
@@ -48,4 +60,78 @@ export async function fetchSeasons() {
 
 export async function fetchSeasonBySlug(slug: string) {
   return seasonRepo.findSeasonBySlug(slug);
+}
+
+type SectionsWithDetails = Awaited<ReturnType<typeof sectionRepo.findAllSectionsWithDetails>>;
+
+export async function fetchAddSessionsContext(slug: string, language: string) {
+  const [season, sections] = await Promise.all([
+    seasonRepo.findSeasonBySlug(slug),
+    sectionRepo.findAllSectionsWithDetails(language),
+  ]);
+  if (!season) return null;
+  return { season, sections };
+}
+
+type DiffMinutesArgs = { startTime: string; endTime: string };
+function diffMinutes({ startTime, endTime }: DiffMinutesArgs): number {
+  const [sh, sm] = startTime.split(':').map(Number);
+  const [eh, em] = endTime.split(':').map(Number);
+  return eh * 60 + em - (sh * 60 + sm);
+}
+
+type CreateSessionsForSeasonInput = {
+  season: { id: string; slug: string };
+  sections: SectionsWithDetails;
+  rows: AddSessionsRow[];
+};
+
+export async function createSessionsForSeason(input: CreateSessionsForSeasonInput): Promise<{
+  createdCount: number;
+  warnings: GeneratorWarning[];
+}> {
+  const generatorSections = input.sections.map(section => ({
+    id: section.id,
+    order: section.order,
+    eligibleTypes: section.exerciseTypes.map(t => ({
+      id: t.id,
+      exerciseIds: t.exercises.map(e => e.id),
+    })),
+  }));
+
+  const programme = generateProgrammeForBatch({
+    sections: generatorSections,
+    rowCount: input.rows.length,
+  });
+
+  const baseSlug = input.season.slug;
+  const proposedSlugs = input.rows.map(row => `${baseSlug}-${row.date}`);
+  const existing = await findPracticeSessionsBySlugPrefix(baseSlug);
+  const taken = new Set(existing.map(e => e.slug));
+
+  const finalSlugs: string[] = [];
+  for (const proposed of proposedSlugs) {
+    const unique = makeUniqueSlug(proposed, [...taken, ...finalSlugs]);
+    finalSlugs.push(unique);
+  }
+
+  await db.$transaction(async tx => {
+    for (let i = 0; i < input.rows.length; i++) {
+      const row = input.rows[i];
+      const scheduledAt = helsinkiWallClockToUtc(row.date, row.startTime);
+      const sessionLength = diffMinutes(row);
+      await createPracticeSessionTx(tx, {
+        slug: finalSlugs[i],
+        sessionLength,
+        seasonId: input.season.id,
+        scheduledAt,
+        sectionItems: programme.sessions[i].items,
+      });
+    }
+  });
+
+  return {
+    createdCount: input.rows.length,
+    warnings: programme.warnings,
+  };
 }

--- a/app/services/sessionAutoGenerator.server.ts
+++ b/app/services/sessionAutoGenerator.server.ts
@@ -1,0 +1,106 @@
+type EligibleType = {
+  id: string;
+  exerciseIds: string[];
+};
+
+type GeneratorSection = {
+  id: string;
+  order: number;
+  eligibleTypes: EligibleType[];
+};
+
+export type GenerateProgrammeInput = {
+  sections: GeneratorSection[];
+  rowCount: number;
+  rng?: () => number;
+};
+
+export type GeneratedItem = {
+  sectionId: string;
+  exerciseTypeId: string;
+  exerciseId: string | null;
+  order: number;
+};
+
+export type GeneratorWarning = {
+  rowIndex: number;
+  sectionId: string;
+  reason: 'no-fresh-drill' | 'no-eligible-types';
+};
+
+export type GenerateProgrammeOutput = {
+  sessions: Array<{ items: GeneratedItem[] }>;
+  warnings: GeneratorWarning[];
+};
+
+function shuffle<T>(items: readonly T[], rng: () => number): T[] {
+  const copy = items.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+export function generateProgrammeForBatch({
+  sections,
+  rowCount,
+  rng = Math.random,
+}: GenerateProgrammeInput): GenerateProgrammeOutput {
+  const sessions: Array<{ items: GeneratedItem[] }> = [];
+  const warnings: GeneratorWarning[] = [];
+
+  for (let i = 0; i < rowCount; i++) {
+    const excluded = new Set<string>();
+    for (let j = Math.max(0, i - 2); j < i; j++) {
+      for (const item of sessions[j].items) {
+        if (item.exerciseId) excluded.add(item.exerciseId);
+      }
+    }
+
+    const items: GeneratedItem[] = [];
+
+    for (const section of sections) {
+      if (section.eligibleTypes.length === 0) {
+        warnings.push({ rowIndex: i, sectionId: section.id, reason: 'no-eligible-types' });
+        continue;
+      }
+
+      const shuffledTypes = shuffle(section.eligibleTypes, rng);
+      let picked: { typeId: string; exerciseId: string } | null = null;
+
+      for (const type of shuffledTypes) {
+        if (type.exerciseIds.length === 0) continue;
+        const shuffledExercises = shuffle(type.exerciseIds, rng);
+        for (const exerciseId of shuffledExercises) {
+          if (!excluded.has(exerciseId)) {
+            picked = { typeId: type.id, exerciseId };
+            break;
+          }
+        }
+        if (picked) break;
+      }
+
+      if (picked) {
+        items.push({
+          sectionId: section.id,
+          exerciseTypeId: picked.typeId,
+          exerciseId: picked.exerciseId,
+          order: section.order,
+        });
+      } else {
+        items.push({
+          sectionId: section.id,
+          exerciseTypeId: shuffledTypes[0].id,
+          exerciseId: null,
+          order: section.order,
+        });
+        warnings.push({ rowIndex: i, sectionId: section.id, reason: 'no-fresh-drill' });
+      }
+    }
+
+    sessions.push({ items });
+  }
+
+  return { sessions, warnings };
+}

--- a/app/utils/timezone.ts
+++ b/app/utils/timezone.ts
@@ -1,0 +1,20 @@
+import { fromZonedTime, toZonedTime, format } from 'date-fns-tz';
+
+export const HELSINKI_TIMEZONE = 'Europe/Helsinki';
+
+export function helsinkiWallClockToUtc(dateString: string, timeString: string): Date {
+  const wallClock = `${dateString}T${timeString}:00`;
+  return fromZonedTime(wallClock, HELSINKI_TIMEZONE);
+}
+
+export function utcToHelsinkiDateString(value: Date): string {
+  return format(toZonedTime(value, HELSINKI_TIMEZONE), 'yyyy-MM-dd', {
+    timeZone: HELSINKI_TIMEZONE,
+  });
+}
+
+export function utcToHelsinkiTimeString(value: Date): string {
+  return format(toZonedTime(value, HELSINKI_TIMEZONE), 'HH:mm', {
+    timeZone: HELSINKI_TIMEZONE,
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@stylexjs/stylex": "^0.18.2",
         "@uiw/react-md-editor": "^4.0.8",
         "cheerio": "^1.1.2",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "i18next": "^25.5.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "i18next-fs-backend": "^2.6.0",
@@ -4485,6 +4487,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@stylexjs/stylex": "^0.18.2",
     "@uiw/react-md-editor": "^4.0.8",
     "cheerio": "^1.1.2",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "i18next": "^25.5.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-fs-backend": "^2.6.0",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -131,6 +131,29 @@
       "7": "Sunday"
     }
   },
+  "addSessions": {
+    "title": "Add practice sessions",
+    "subtitle": "Generate one or more practice sessions for season \"{{season}}\"",
+    "section": "Initial sessions",
+    "howMany": "How many sessions to create?",
+    "regenerate": "Regenerate from defaults",
+    "date": "Date",
+    "startTime": "Start time",
+    "endTime": "End time",
+    "remove": "Remove",
+    "rowDate": "Session {{index}} date",
+    "rowStartTime": "Session {{index}} start time",
+    "rowEndTime": "Session {{index}} end time",
+    "removeRow": "Remove session {{index}}",
+    "empty": "No sessions yet. Set a count above.",
+    "atLeastOne": "At least one session is required",
+    "allFieldsRequired": "All fields are required",
+    "endAfterStart": "End time must be after start time",
+    "submit": "Create sessions",
+    "cta": "Add sessions",
+    "warningBanner_one": "{{count}} section fell back to type-only — the exercise bank didn't have a fresh drill.",
+    "warningBanner_other": "{{count}} sections fell back to type-only — the exercise bank didn't have a fresh drill."
+  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -131,6 +131,29 @@
       "7": "Sunnuntai"
     }
   },
+  "addSessions": {
+    "title": "Lisää harjoituskertoja",
+    "subtitle": "Generoi yksi tai useampi harjoituskerta kaudelle \"{{season}}\"",
+    "section": "Alkukerrat",
+    "howMany": "Kuinka monta harjoituskertaa luodaan?",
+    "regenerate": "Luo uudelleen oletuksilla",
+    "date": "Päivämäärä",
+    "startTime": "Alkamisaika",
+    "endTime": "Loppumisaika",
+    "remove": "Poista",
+    "rowDate": "Harjoituskerta {{index}} päivämäärä",
+    "rowStartTime": "Harjoituskerta {{index}} alkamisaika",
+    "rowEndTime": "Harjoituskerta {{index}} loppumisaika",
+    "removeRow": "Poista harjoituskerta {{index}}",
+    "empty": "Ei harjoituskertoja. Aseta kappalemäärä yllä.",
+    "atLeastOne": "Ainakin yksi harjoituskerta vaaditaan",
+    "allFieldsRequired": "Kaikki kentät ovat pakollisia",
+    "endAfterStart": "Loppumisajan tulee olla alkamisajan jälkeen",
+    "submit": "Luo harjoituskerrat",
+    "cta": "Lisää harjoituskertoja",
+    "warningBanner_one": "{{count}} osio sai vain tyypin (ei harjoitetta) — harjoituspankki ei kattanut riittävästi tähän erään.",
+    "warningBanner_other": "{{count}} osiota saivat vain tyypin (ei harjoitetta) — harjoituspankki ei kattanut riittävästi tähän erään."
+  },
   "common": {
     "save": "Tallenna",
     "cancel": "Peruuta",

--- a/tests/sessionAutoGenerator.test.ts
+++ b/tests/sessionAutoGenerator.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { generateProgrammeForBatch } from '~/services/sessionAutoGenerator.server';
+
+function seededRng(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 0x100000000;
+    return state / 0x100000000;
+  };
+}
+
+const fiveSections = [
+  {
+    id: 'sec-1',
+    order: 1,
+    eligibleTypes: [{ id: 'type-1', exerciseIds: ['ex-1a', 'ex-1b', 'ex-1c'] }],
+  },
+  {
+    id: 'sec-2',
+    order: 2,
+    eligibleTypes: [{ id: 'type-2', exerciseIds: ['ex-2a', 'ex-2b', 'ex-2c'] }],
+  },
+  {
+    id: 'sec-3',
+    order: 3,
+    eligibleTypes: [{ id: 'type-3', exerciseIds: ['ex-3a', 'ex-3b', 'ex-3c'] }],
+  },
+  {
+    id: 'sec-4',
+    order: 4,
+    eligibleTypes: [{ id: 'type-4', exerciseIds: ['ex-4a', 'ex-4b', 'ex-4c'] }],
+  },
+  {
+    id: 'sec-5',
+    order: 5,
+    eligibleTypes: [{ id: 'type-5', exerciseIds: ['ex-5a', 'ex-5b', 'ex-5c'] }],
+  },
+];
+
+describe('generateProgrammeForBatch', () => {
+  it('produces one item per section per row', () => {
+    const result = generateProgrammeForBatch({
+      sections: fiveSections,
+      rowCount: 3,
+      rng: seededRng(1),
+    });
+
+    expect(result.sessions).toHaveLength(3);
+    for (const session of result.sessions) {
+      expect(session.items).toHaveLength(5);
+      const sectionsCovered = session.items.map(i => i.sectionId).sort();
+      expect(sectionsCovered).toEqual(['sec-1', 'sec-2', 'sec-3', 'sec-4', 'sec-5']);
+    }
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('respects the rolling 2-row exclusion window per section', () => {
+    const result = generateProgrammeForBatch({
+      sections: fiveSections,
+      rowCount: 3,
+      rng: seededRng(42),
+    });
+
+    for (let row = 1; row < 3; row++) {
+      const previousRow = result.sessions[row - 1];
+      for (const item of result.sessions[row].items) {
+        const previousAtSameSection = previousRow.items.find(p => p.sectionId === item.sectionId);
+        if (previousAtSameSection?.exerciseId && item.exerciseId) {
+          expect(item.exerciseId).not.toBe(previousAtSameSection.exerciseId);
+        }
+      }
+    }
+  });
+
+  it('falls back to type-only when no fresh drill is available', () => {
+    const sparseSection = {
+      id: 'sec-1',
+      order: 1,
+      eligibleTypes: [{ id: 'type-1', exerciseIds: ['only-one'] }],
+    };
+
+    const result = generateProgrammeForBatch({
+      sections: [sparseSection],
+      rowCount: 3,
+      rng: seededRng(7),
+    });
+
+    expect(result.sessions[0].items[0].exerciseId).toBe('only-one');
+    expect(result.sessions[1].items[0].exerciseId).toBe(null);
+    expect(result.warnings).toContainEqual({
+      rowIndex: 1,
+      sectionId: 'sec-1',
+      reason: 'no-fresh-drill',
+    });
+  });
+
+  it('emits a no-eligible-types warning and skips items when section has no types', () => {
+    const result = generateProgrammeForBatch({
+      sections: [
+        { id: 'sec-empty', order: 1, eligibleTypes: [] },
+        { id: 'sec-ok', order: 2, eligibleTypes: [{ id: 't', exerciseIds: ['x'] }] },
+      ],
+      rowCount: 1,
+      rng: seededRng(3),
+    });
+
+    expect(result.sessions[0].items).toHaveLength(1);
+    expect(result.sessions[0].items[0].sectionId).toBe('sec-ok');
+    expect(result.warnings).toContainEqual({
+      rowIndex: 0,
+      sectionId: 'sec-empty',
+      reason: 'no-eligible-types',
+    });
+  });
+
+  it('is deterministic under the same seed', () => {
+    const a = generateProgrammeForBatch({
+      sections: fiveSections,
+      rowCount: 4,
+      rng: seededRng(123),
+    });
+    const b = generateProgrammeForBatch({
+      sections: fiveSections,
+      rowCount: 4,
+      rng: seededRng(123),
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('handles rowCount of 0', () => {
+    const result = generateProgrammeForBatch({
+      sections: fiveSections,
+      rowCount: 0,
+      rng: seededRng(1),
+    });
+    expect(result.sessions).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- New `/seasons/$slug/add-sessions` route: N-row inline editor (count + date/start/end per row), seeded from the season's defaults. Submits a JSON `rows` payload validated by Zod; end time reverse-computes `sessionLength`.
- Pure auto-gen `generateProgrammeForBatch` (`app/services/sessionAutoGenerator.server.ts`) with rolling 2-row exclusion and type-only fallback when the bank has no fresh drill. Shipped with 6 unit tests.
- Atomic batch write: a single `db.$transaction` creates N `PracticeSession` rows + their `sectionItems`, all linked to the season via `seasonId` with `scheduledAt` stored UTC (Helsinki wall-clock → UTC via new `app/utils/timezone.ts`, depends on `date-fns-tz`).
- Slug per session: `${season.slug}-${YYYY-MM-DD}`, collisions resolved against existing sessions (`findPracticeSessionsBySlugPrefix`) and within-batch via `makeUniqueSlug`.
- Type-only fallback warnings surfaced via `?warnings=N` query param + amber banner on the season detail page.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --write` — clean.
- [x] `vitest tests/sessionAutoGenerator.test.ts` — 6/6 passing (one item per section, exclusion respected, type-only fallback, no-eligible-types skip, deterministic under seeded RNG, rowCount=0).
- [x] Browser sweep:
  - Created Kevät 2026, hit "Lisää harjoituskertoja" → 3 rows seeded for the next 3 Wednesdays at 17:00–18:30 (matches season defaults).
  - Submitted → redirected to `/seasons/kevat-2026?warnings=7`. 3 sessions created, all linked, `scheduledAt` correct, `sessionLength` 90.
  - Verified one session's detail page renders all 5 sections; type-only fallbacks show as plain section names, picked exercises show as links.
  - Re-submitted same dates → slug collisions resolve as `-2026-05-06-2`, etc.
  - Deleted season → linked sessions detached (verified via `/practise-sessions`).
  - Console: 0 errors, 0 warnings.
- [ ] Responsive viewport check — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)