### PR TITLE
Standalone vs season cleanup + nav (PR D)

### DIFF
--- a/app/components/AddSessionsForm.tsx
+++ b/app/components/AddSessionsForm.tsx
@@ -102,7 +102,9 @@ export default function AddSessionsForm({
 
   const handleCountChange = (raw: string) => {
     const next = Number(raw);
-    if (!Number.isFinite(next) || next < MIN_SESSIONS || next > MAX_SESSIONS) return;
+    if (!Number.isFinite(next) || next < MIN_SESSIONS || next > MAX_SESSIONS) {
+      return;
+    }
     setCount(next);
     if (next > rows.length) {
       const additional = next - rows.length;
@@ -140,7 +142,9 @@ export default function AddSessionsForm({
   const handleStartTimeChange = (id: string, newStart: string) => {
     setRows(prev =>
       prev.map(r => {
-        if (r.id !== id) return r;
+        if (r.id !== id) {
+          return r;
+        }
         const duration = diffMinutes(r.startTime, r.endTime);
         return {
           ...r,

--- a/app/components/PractiseSessionSection.tsx
+++ b/app/components/PractiseSessionSection.tsx
@@ -57,10 +57,14 @@ export function PractiseSessionSection({
   };
 
   const handleAdd = () => {
-    if (!selectedTypeValue) return;
+    if (!selectedTypeValue) {
+      return;
+    }
 
     if (hasExercises) {
-      if (!selectedExerciseId) return;
+      if (!selectedExerciseId) {
+        return;
+      }
       const exercise = selectedType!.exercises!.find(e => e.value === selectedExerciseId);
       if (exercise) {
         onAddItem({

--- a/app/hooks/useExerciseFilters.ts
+++ b/app/hooks/useExerciseFilters.ts
@@ -86,14 +86,18 @@ export function useExerciseFilters({ exerciseTypes }: UseExerciseFiltersProps) {
   // Check if a parent type is selected (all children selected)
   const isParentSelected = (parentId: string): boolean => {
     const childIds = getChildIds(parentId);
-    if (childIds.length === 0) return selectedTypeIds.includes(parentId);
+    if (childIds.length === 0) {
+      return selectedTypeIds.includes(parentId);
+    }
     return childIds.every(id => selectedTypeIds.includes(id));
   };
 
   // Check if parent is indeterminate (some but not all children selected)
   const isParentIndeterminate = (parentId: string): boolean => {
     const childIds = getChildIds(parentId);
-    if (childIds.length === 0) return false;
+    if (childIds.length === 0) {
+      return false;
+    }
     const selectedChildren = childIds.filter(id => selectedTypeIds.includes(id));
     return selectedChildren.length > 0 && selectedChildren.length < childIds.length;
   };

--- a/app/pages/EditPractiseSessionPage.tsx
+++ b/app/pages/EditPractiseSessionPage.tsx
@@ -38,9 +38,13 @@ type EditPractiseSessionPageProps = {
 };
 
 function scheduledAtToInputs(value: Date | string | null): { date: string; time: string } {
-  if (!value) return { date: '', time: '' };
+  if (!value) {
+    return { date: '', time: '' };
+  }
   const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return { date: '', time: '' };
+  if (Number.isNaN(d.getTime())) {
+    return { date: '', time: '' };
+  }
   return { date: utcToHelsinkiDateString(d), time: utcToHelsinkiTimeString(d) };
 }
 
@@ -101,9 +105,15 @@ export default function EditPractiseSessionPage({
   const handleRemoveItem = (sectionId: string, itemValue: string, exerciseId?: string) => {
     setSelectedItems(prev =>
       prev.filter(item => {
-        if (item.sectionId !== sectionId) return true;
-        if (item.itemValue !== itemValue) return true;
-        if (exerciseId) return item.exerciseId !== exerciseId;
+        if (item.sectionId !== sectionId) {
+          return true;
+        }
+        if (item.itemValue !== itemValue) {
+          return true;
+        }
+        if (exerciseId) {
+          return item.exerciseId !== exerciseId;
+        }
         return false;
       })
     );

--- a/app/pages/EditPractiseSessionPage.tsx
+++ b/app/pages/EditPractiseSessionPage.tsx
@@ -1,17 +1,20 @@
 import { useState } from 'react';
-import { Form, useSubmit } from 'react-router';
+import { Form, Link, useSubmit } from 'react-router';
 import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
 import { PractiseSessionSummary } from '~/components/PractiseSessionSummary';
 import { Button } from '~/components/Button';
 import { useTranslation } from 'react-i18next';
+import { utcToHelsinkiDateString, utcToHelsinkiTimeString } from '~/utils/timezone';
 
 type PracticeSessionData = {
   id: string;
   name: string | null;
   description: string | null;
   sessionLength: number;
+  scheduledAt: Date | string | null;
+  season: { slug: string; name: string } | null;
   sectionItems: Array<{
     id: string;
     order: number;
@@ -33,6 +36,13 @@ type EditPractiseSessionPageProps = {
   session: PracticeSessionData;
   sections: Section[];
 };
+
+function scheduledAtToInputs(value: Date | string | null): { date: string; time: string } {
+  if (!value) return { date: '', time: '' };
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return { date: '', time: '' };
+  return { date: utcToHelsinkiDateString(d), time: utcToHelsinkiTimeString(d) };
+}
 
 export default function EditPractiseSessionPage({
   session,
@@ -56,6 +66,9 @@ export default function EditPractiseSessionPage({
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>(initialSelectedItems);
   const [name, setName] = useState<string>(session.name || '');
   const [description, setDescription] = useState<string>(session.description || '');
+  const initialScheduled = scheduledAtToInputs(session.scheduledAt);
+  const [scheduledDate, setScheduledDate] = useState<string>(initialScheduled.date);
+  const [scheduledTime, setScheduledTime] = useState<string>(initialScheduled.time);
   const [errors, setErrors] = useState<{ name?: string; items?: string }>({});
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
@@ -137,6 +150,18 @@ export default function EditPractiseSessionPage({
       <h1 className="mb-6 text-3xl font-bold">{t('sessions.edit')}</h1>
 
       <Form method="post" onSubmit={handleSubmit}>
+        {session.season && (
+          <div className="mb-6 rounded border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+            {t('sessions.partOfSeason')}{' '}
+            <Link
+              to={`/seasons/${session.season.slug}`}
+              className="font-semibold underline hover:text-blue-700"
+            >
+              {session.season.name}
+            </Link>
+          </div>
+        )}
+
         {/* Name and Description */}
         <div className="mb-6 space-y-4">
           <div>
@@ -169,6 +194,40 @@ export default function EditPractiseSessionPage({
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder={t('sessions.descriptionPlaceholder')}
             />
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label
+                htmlFor="scheduledDate"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {t('sessions.scheduledDateOptional')}
+              </label>
+              <input
+                type="date"
+                id="scheduledDate"
+                name="scheduledDate"
+                value={scheduledDate}
+                onChange={e => setScheduledDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="scheduledTime"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {t('sessions.scheduledTimeOptional')}
+              </label>
+              <input
+                type="time"
+                id="scheduledTime"
+                name="scheduledTime"
+                value={scheduledTime}
+                onChange={e => setScheduledTime(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
           </div>
         </div>
 

--- a/app/pages/EditSeasonPage.tsx
+++ b/app/pages/EditSeasonPage.tsx
@@ -22,9 +22,13 @@ type EditSeasonPageProps = {
 };
 
 function toDateInputValue(value: Date | string | null): string {
-  if (!value) return '';
+  if (!value) {
+    return '';
+  }
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '';
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');

--- a/app/pages/HomePage.tsx
+++ b/app/pages/HomePage.tsx
@@ -46,6 +46,12 @@ export default function HomePage() {
           title={t('home.createExercise')}
           href={'/exercises/new'}
         />
+
+        <FeatureBox
+          imagePath="/app/asssets/images/exercise-plan.png"
+          title={t('home.seasons')}
+          href="/seasons"
+        />
       </div>
     </div>
   );

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -29,6 +29,8 @@ type PracticeSessionData = {
   name: string | null;
   description: string | null;
   sessionLength: number;
+  scheduledAt: Date | string | null;
+  season: { slug: string; name: string } | null;
   createdAt: Date;
   updatedAt: Date;
   sectionItems: SectionItem[];
@@ -67,7 +69,7 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
       {/* Header */}
       <div className="mb-6">
         <Link
-          to="/practise-sessions"
+          to={session.season ? `/seasons/${session.season.slug}` : '/practise-sessions'}
           className="text-blue-600 hover:text-blue-800 mb-4 inline-flex items-center"
         >
           <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -78,7 +80,9 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
               d="M15 19l-7-7 7-7"
             />
           </svg>
-          {t('sessions.backToSessions')}
+          {session.season
+            ? t('sessions.backToSeason', { name: session.season.name })
+            : t('sessions.backToSessions')}
         </Link>
         <div className="flex justify-between items-start mt-2">
           <h1 className="text-3xl font-bold">{session.name || t('sessions.untitledSession')}</h1>
@@ -112,6 +116,19 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
             </svg>
             {session.sessionLength} {t('common.minutes')}
           </div>
+          {session.scheduledAt && (
+            <div className="flex items-center">
+              <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              {t('sessions.scheduled')}: {new Date(session.scheduledAt).toLocaleString('fi-FI')}
+            </div>
+          )}
         </div>
       </div>
 

--- a/app/pages/PractiseSessionForm.tsx
+++ b/app/pages/PractiseSessionForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Form } from 'react-router';
+import { Form, Link } from 'react-router';
 import type { PractiseLength, SelectedItem, Section } from '~/types';
 import { PractiseSessionLengthSelector } from '~/components/PractiseSessionLengthSelector';
 import { PractiseSessionSection } from '~/components/PractiseSessionSection';
@@ -7,16 +7,33 @@ import { PractiseSessionSummary } from '~/components/PractiseSessionSummary';
 import { Button } from '~/components/Button';
 import { useTranslation } from 'react-i18next';
 
-type PractiseSessionFormProps = {
-  sections: Section[];
+type SeasonBadge = {
+  slug: string;
+  name: string;
 };
 
-export default function PractiseSessionForm({ sections }: PractiseSessionFormProps) {
+type PractiseSessionFormProps = {
+  sections: Section[];
+  defaultScheduledDate?: string;
+  defaultScheduledTime?: string;
+  seasonBadge?: SeasonBadge;
+  hiddenSeasonId?: string;
+};
+
+export default function PractiseSessionForm({
+  sections,
+  defaultScheduledDate,
+  defaultScheduledTime,
+  seasonBadge,
+  hiddenSeasonId,
+}: PractiseSessionFormProps) {
   const { t } = useTranslation();
   const [practiseLength, setPractiseLength] = useState<PractiseLength>(60);
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([]);
   const [name, setName] = useState<string>('');
   const [description, setDescription] = useState<string>('');
+  const [scheduledDate, setScheduledDate] = useState<string>(defaultScheduledDate ?? '');
+  const [scheduledTime, setScheduledTime] = useState<string>(defaultScheduledTime ?? '');
   const [errors, setErrors] = useState<{ name?: string; items?: string }>({});
 
   // Get section duration based on practise length
@@ -83,6 +100,19 @@ export default function PractiseSessionForm({ sections }: PractiseSessionFormPro
       <h1 className="mb-6 text-3xl font-bold">{t('sessions.design')}</h1>
 
       <Form method="post" onSubmit={handleSubmit}>
+        {seasonBadge && (
+          <div className="mb-6 rounded border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+            {t('sessions.partOfSeason')}{' '}
+            <Link
+              to={`/seasons/${seasonBadge.slug}`}
+              className="font-semibold underline hover:text-blue-700"
+            >
+              {seasonBadge.name}
+            </Link>
+          </div>
+        )}
+        {hiddenSeasonId && <input type="hidden" name="seasonId" value={hiddenSeasonId} />}
+
         {/* Name and Description */}
         <div className="mb-6 space-y-4">
           <div>
@@ -115,6 +145,40 @@ export default function PractiseSessionForm({ sections }: PractiseSessionFormPro
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder={t('sessions.descriptionPlaceholder')}
             />
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label
+                htmlFor="scheduledDate"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {t('sessions.scheduledDateOptional')}
+              </label>
+              <input
+                type="date"
+                id="scheduledDate"
+                name="scheduledDate"
+                value={scheduledDate}
+                onChange={e => setScheduledDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="scheduledTime"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {t('sessions.scheduledTimeOptional')}
+              </label>
+              <input
+                type="time"
+                id="scheduledTime"
+                name="scheduledTime"
+                value={scheduledTime}
+                onChange={e => setScheduledTime(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
           </div>
         </div>
 

--- a/app/pages/PractiseSessionForm.tsx
+++ b/app/pages/PractiseSessionForm.tsx
@@ -65,9 +65,15 @@ export default function PractiseSessionForm({
   const handleRemoveItem = (sectionId: string, itemValue: string, exerciseId?: string) => {
     setSelectedItems(prev =>
       prev.filter(item => {
-        if (item.sectionId !== sectionId) return true;
-        if (item.itemValue !== itemValue) return true;
-        if (exerciseId) return item.exerciseId !== exerciseId;
+        if (item.sectionId !== sectionId) {
+          return true;
+        }
+        if (item.itemValue !== itemValue) {
+          return true;
+        }
+        if (exerciseId) {
+          return item.exerciseId !== exerciseId;
+        }
         return false;
       })
     );

--- a/app/pages/PractiseSessionsList.tsx
+++ b/app/pages/PractiseSessionsList.tsx
@@ -35,6 +35,13 @@ export default function PractiseSessionsList({ sessions }: PractiseSessionsListP
         </Link>
       </div>
 
+      <div className="mb-6 rounded border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+        {t('sessions.standaloneBanner')}{' '}
+        <Link to="/seasons" className="font-semibold underline hover:text-blue-700">
+          {t('sessions.standaloneBannerLink')}
+        </Link>
+      </div>
+
       {sessions.length === 0 ? (
         <div className="text-center py-12 bg-gray-50 rounded-lg">
           <svg

--- a/app/repositories/practiceSession.server.ts
+++ b/app/repositories/practiceSession.server.ts
@@ -69,8 +69,13 @@ export async function createPracticeSessionTx(
   });
 }
 
-export async function findAllPracticeSessions() {
+type FindPracticeSessionsOptions = {
+  standaloneOnly?: boolean;
+};
+
+export async function findAllPracticeSessions(options: FindPracticeSessionsOptions = {}) {
   return db.practiceSession.findMany({
+    where: options.standaloneOnly ? { seasonId: null } : undefined,
     orderBy: {
       createdAt: 'desc',
     },
@@ -88,6 +93,9 @@ export async function findPracticeSessionById(id: string, language: string) {
   return db.practiceSession.findUnique({
     where: { id },
     include: {
+      season: {
+        select: { slug: true, name: true },
+      },
       sectionItems: {
         orderBy: [{ sectionId: 'asc' }, { order: 'asc' }],
         include: {
@@ -118,6 +126,9 @@ export async function findPracticeSessionBySlug(slug: string, language: string) 
   return db.practiceSession.findUnique({
     where: { slug },
     include: {
+      season: {
+        select: { slug: true, name: true },
+      },
       sectionItems: {
         orderBy: [{ sectionId: 'asc' }, { order: 'asc' }],
         include: {
@@ -148,6 +159,7 @@ type UpdatePracticeSessionData = {
   name?: string;
   description?: string;
   sessionLength: number;
+  scheduledAt?: Date | null;
   sectionItems: Array<{
     sectionId: string;
     exerciseTypeId: string;
@@ -168,6 +180,7 @@ export async function updatePracticeSession(id: string, data: UpdatePracticeSess
         name: data.name || null,
         description: data.description || null,
         sessionLength: data.sessionLength,
+        scheduledAt: data.scheduledAt ?? null,
         sectionItems: {
           create: data.sectionItems,
         },

--- a/app/repositories/season.server.ts
+++ b/app/repositories/season.server.ts
@@ -49,6 +49,13 @@ export async function findAllSeasons() {
   });
 }
 
+export async function findSeasonById(id: string) {
+  return db.season.findUnique({
+    where: { id },
+    select: { id: true, slug: true, name: true },
+  });
+}
+
 export async function findSeasonBySlug(slug: string) {
   return db.season.findUnique({
     where: { slug },

--- a/app/routes/practise-sessions.$id_.edit.tsx
+++ b/app/routes/practise-sessions.$id_.edit.tsx
@@ -16,6 +16,7 @@ import {
 import { fetchSectionsForPractiseSession } from '~/services/sections.server';
 import type { SelectedItem } from '~/types';
 import { getDefaultLocale } from '~/utils/locale.server';
+import { helsinkiWallClockToUtc } from '~/utils/timezone';
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data?.session) {
@@ -48,12 +49,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const sessionLength = parseInt(formData.get('sessionLength') as string, 10);
   const selectedItemsJson = formData.get('selectedItems') as string;
   const selectedItems: SelectedItem[] = JSON.parse(selectedItemsJson);
+  const scheduledDate = (formData.get('scheduledDate') as string | null) || '';
+  const scheduledTime = (formData.get('scheduledTime') as string | null) || '';
+  const scheduledAt =
+    scheduledDate && scheduledTime ? helsinkiWallClockToUtc(scheduledDate, scheduledTime) : null;
 
   const session = await updatePracticeSession({
     id: params.id!,
     name: name || undefined,
     description: description || undefined,
     sessionLength,
+    scheduledAt,
     selectedItems,
   });
 

--- a/app/routes/practise-sessions._index.tsx
+++ b/app/routes/practise-sessions._index.tsx
@@ -8,7 +8,7 @@ export const meta: MetaFunction = () => {
 };
 
 export async function loader() {
-  const sessions = await fetchPracticeSessions();
+  const sessions = await fetchPracticeSessions({ standaloneOnly: true });
   return { sessions };
 }
 

--- a/app/routes/practise-sessions.new.tsx
+++ b/app/routes/practise-sessions.new.tsx
@@ -1,18 +1,32 @@
-import { redirect, type ActionFunctionArgs, type MetaFunction } from 'react-router';
+import {
+  redirect,
+  type ActionFunctionArgs,
+  type MetaFunction,
+  type LoaderFunctionArgs,
+} from 'react-router';
 import { useLoaderData } from 'react-router';
 import PractiseSessionForm from '~/pages/PractiseSessionForm';
 import { fetchSectionsForPractiseSession } from '~/services/sections.server';
 import { createPracticeSession } from '~/services/practiceSessions.server';
+import { fetchSeasonById } from '~/services/seasons.server';
 import type { SelectedItem } from '~/types';
 import { getDefaultLocale } from '~/utils/locale.server';
+import { helsinkiWallClockToUtc } from '~/utils/timezone';
 
 export const meta: MetaFunction = () => {
   return [{ title: 'Design Practice Session - Harkkapankki' }];
 };
 
-export async function loader() {
-  const sections = await fetchSectionsForPractiseSession(getDefaultLocale());
-  return { sections };
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const seasonId = url.searchParams.get('seasonId');
+
+  const [sections, season] = await Promise.all([
+    fetchSectionsForPractiseSession(getDefaultLocale()),
+    seasonId ? fetchSeasonById(seasonId) : Promise.resolve(null),
+  ]);
+
+  return { sections, season };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -22,18 +36,39 @@ export async function action({ request }: ActionFunctionArgs) {
   const sessionLength = parseInt(formData.get('sessionLength') as string, 10);
   const selectedItemsJson = formData.get('selectedItems') as string;
   const selectedItems: SelectedItem[] = JSON.parse(selectedItemsJson);
+  const seasonId = (formData.get('seasonId') as string | null) || null;
+  const scheduledDate = (formData.get('scheduledDate') as string | null) || '';
+  const scheduledTime = (formData.get('scheduledTime') as string | null) || '';
+
+  const scheduledAt =
+    scheduledDate && scheduledTime ? helsinkiWallClockToUtc(scheduledDate, scheduledTime) : null;
 
   const session = await createPracticeSession({
     name: name || undefined,
     description: description || undefined,
     sessionLength,
+    seasonId,
+    scheduledAt,
     selectedItems,
   });
+
+  if (seasonId) {
+    const season = await fetchSeasonById(seasonId);
+    if (season) {
+      return redirect(`/seasons/${season.slug}`);
+    }
+  }
 
   return redirect(`/practise-sessions/${session.slug}`);
 }
 
 export default function NewPractiseSession() {
-  const { sections } = useLoaderData<typeof loader>();
-  return <PractiseSessionForm sections={sections} />;
+  const { sections, season } = useLoaderData<typeof loader>();
+  return (
+    <PractiseSessionForm
+      sections={sections}
+      seasonBadge={season ? { slug: season.slug, name: season.name } : undefined}
+      hiddenSeasonId={season?.id}
+    />
+  );
 }

--- a/app/schemas/season.ts
+++ b/app/schemas/season.ts
@@ -39,7 +39,9 @@ export const seasonSchema = z
           .optional()
           .refine(
             val => {
-              if (val === undefined) return true;
+              if (val === undefined) {
+                return true;
+              }
               const num = Number(val);
               return Number.isInteger(num) && num >= 1 && num <= 7;
             },
@@ -70,7 +72,9 @@ export const seasonSchema = z
   })
   .refine(
     data => {
-      if (!data.startDate || !data.endDate) return true;
+      if (!data.startDate || !data.endDate) {
+        return true;
+      }
       return data.endDate >= data.startDate;
     },
     {

--- a/app/services/practiceSessions.server.ts
+++ b/app/services/practiceSessions.server.ts
@@ -7,6 +7,8 @@ type CreatePracticeSessionInput = {
   name?: string;
   description?: string;
   sessionLength: number;
+  seasonId?: string | null;
+  scheduledAt?: Date | null;
   selectedItems: SelectedItem[];
 };
 
@@ -48,6 +50,8 @@ export async function createPracticeSession(input: CreatePracticeSessionInput) {
     name: input.name,
     description: input.description,
     sessionLength: input.sessionLength,
+    seasonId: input.seasonId ?? null,
+    scheduledAt: input.scheduledAt ?? null,
     sectionItems,
   });
 }
@@ -57,6 +61,7 @@ type UpdatePracticeSessionInput = {
   name?: string;
   description?: string;
   sessionLength: number;
+  scheduledAt?: Date | null;
   selectedItems: SelectedItem[];
 };
 
@@ -85,6 +90,7 @@ export async function updatePracticeSession(input: UpdatePracticeSessionInput) {
     name: input.name,
     description: input.description,
     sessionLength: input.sessionLength,
+    scheduledAt: input.scheduledAt ?? null,
     sectionItems,
   });
 }
@@ -93,8 +99,14 @@ export async function deletePracticeSession(id: string) {
   return practiceSessionRepo.deletePracticeSession(id);
 }
 
-export async function fetchPracticeSessions() {
-  return practiceSessionRepo.findAllPracticeSessions();
+type FetchPracticeSessionsOptions = {
+  standaloneOnly?: boolean;
+};
+
+export async function fetchPracticeSessions(options: FetchPracticeSessionsOptions = {}) {
+  return practiceSessionRepo.findAllPracticeSessions({
+    standaloneOnly: options.standaloneOnly,
+  });
 }
 
 export async function fetchPracticeSessionById(id: string, language: string = getDefaultLocale()) {

--- a/app/services/seasons.server.ts
+++ b/app/services/seasons.server.ts
@@ -62,6 +62,10 @@ export async function fetchSeasonBySlug(slug: string) {
   return seasonRepo.findSeasonBySlug(slug);
 }
 
+export async function fetchSeasonById(id: string) {
+  return seasonRepo.findSeasonById(id);
+}
+
 type SectionsWithDetails = Awaited<ReturnType<typeof sectionRepo.findAllSectionsWithDetails>>;
 
 export async function fetchAddSessionsContext(slug: string, language: string) {

--- a/app/services/seasons.server.ts
+++ b/app/services/seasons.server.ts
@@ -73,7 +73,9 @@ export async function fetchAddSessionsContext(slug: string, language: string) {
     seasonRepo.findSeasonBySlug(slug),
     sectionRepo.findAllSectionsWithDetails(language),
   ]);
-  if (!season) return null;
+  if (!season) {
+    return null;
+  }
   return { season, sections };
 }
 

--- a/app/services/sessionAutoGenerator.server.ts
+++ b/app/services/sessionAutoGenerator.server.ts
@@ -54,7 +54,9 @@ export function generateProgrammeForBatch({
     const excluded = new Set<string>();
     for (let j = Math.max(0, i - 2); j < i; j++) {
       for (const item of sessions[j].items) {
-        if (item.exerciseId) excluded.add(item.exerciseId);
+        if (item.exerciseId) {
+          excluded.add(item.exerciseId);
+        }
       }
     }
 
@@ -70,7 +72,9 @@ export function generateProgrammeForBatch({
       let picked: { typeId: string; exerciseId: string } | null = null;
 
       for (const type of shuffledTypes) {
-        if (type.exerciseIds.length === 0) continue;
+        if (type.exerciseIds.length === 0) {
+          continue;
+        }
         const shuffledExercises = shuffle(type.exerciseIds, rng);
         for (const exerciseId of shuffledExercises) {
           if (!excluded.has(exerciseId)) {
@@ -78,7 +82,9 @@ export function generateProgrammeForBatch({
             break;
           }
         }
-        if (picked) break;
+        if (picked) {
+          break;
+        }
       }
 
       if (picked) {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -9,7 +9,8 @@
   "home": {
     "designSession": "Design a practice session",
     "exerciseBank": "Exercise bank",
-    "createExercise": "Create a new exercise"
+    "createExercise": "Create a new exercise",
+    "seasons": "Seasons"
   },
   "exercises": {
     "title": "Exercises",
@@ -82,7 +83,14 @@
     "sessionPlaceholder": "e.g., Morning practice session",
     "descriptionPlaceholder": "Add any notes about this session...",
     "item": "item",
-    "items": "items"
+    "items": "items",
+    "scheduledDateOptional": "Scheduled date (optional)",
+    "scheduledTimeOptional": "Scheduled time (optional)",
+    "scheduled": "Scheduled",
+    "partOfSeason": "Part of season",
+    "backToSeason": "Back to season {{name}}",
+    "standaloneBanner": "This list shows standalone practice sessions only. Season-linked sessions live under their season.",
+    "standaloneBannerLink": "Open seasons"
   },
   "seasons": {
     "title": "Seasons",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -9,7 +9,8 @@
   "home": {
     "designSession": "Suunnittele harjoituskerta",
     "exerciseBank": "Harkkapankki",
-    "createExercise": "Luo uusi harjoitus"
+    "createExercise": "Luo uusi harjoitus",
+    "seasons": "Kaudet"
   },
   "exercises": {
     "title": "Harjoitukset",
@@ -82,7 +83,14 @@
     "sessionPlaceholder": "esim. Aamuharjoitus",
     "descriptionPlaceholder": "Lisää muistiinpanoja harjoituksesta...",
     "item": "kohde",
-    "items": "kohdetta"
+    "items": "kohdetta",
+    "scheduledDateOptional": "Ajankohta — päivä (valinnainen)",
+    "scheduledTimeOptional": "Ajankohta — kellonaika (valinnainen)",
+    "scheduled": "Ajankohta",
+    "partOfSeason": "Osa kautta",
+    "backToSeason": "Takaisin kauteen {{name}}",
+    "standaloneBanner": "Tämä lista näyttää vain yksittäiset harjoituskerrat. Kausiin sidotut harjoituskerrat löytyvät kausinäkymästä.",
+    "standaloneBannerLink": "Avaa kausinäkymä"
   },
   "seasons": {
     "title": "Kaudet",


### PR DESCRIPTION
## Summary
Closes out Phase 1 of the season-planning feature.

- `/practise-sessions` filtered to standalone-only (`seasonId IS NULL`) with an info banner linking to `/seasons`. New `standaloneOnly` option threaded through the repo + service.
- `PractiseSessionForm` (new + edit) gains optional `scheduledAt` (date + time inputs, stored UTC via the Helsinki helper added in PR C). When `seasonId` is set, an inline "part of season X" badge links back; per the Phase 1 plan, `seasonId` is only set at creation and not editable afterwards.
- `/practise-sessions/new?seasonId=$ID` resolves the season server-side, renders the badge, hides the seasonId in the form, and redirects back to `/seasons/$slug` on save.
- `/practise-sessions/$id/edit` persists `scheduledAt`; the season association is preserved untouched.
- Practice-session detail back-link points to `/seasons/$slug` when the session is season-linked, and shows "Ajankohta: 6.5.2026 klo 17.00" when scheduled.
- Home page gets a "Kaudet" / "Seasons" card.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --write` — clean.
- [x] `vitest tests/sessionAutoGenerator.test.ts` — 6/6 still passing.
- [x] Browser sweep:
  - Home page now shows the Kaudet card.
  - `/practise-sessions` shows the standalone-only banner.
  - Created Syksy 2026 → "Add sessions" → 3 sessions linked. Listed under the season; **not** listed under `/practise-sessions`.
  - Practice session detail: back-link goes to `/seasons/syksy-2026`; scheduledAt rendered in Helsinki time.
  - Edit form pre-populates `scheduledDate=2026-05-06`, `scheduledTime=17:00`, badge "Osa kautta Syksy 2026".
  - `/practise-sessions/new?seasonId=…` shows badge + hidden seasonId input.
  - `/practise-sessions/new` (no query) shows no badge, no hidden seasonId, scheduledAt fields still present.
  - Console: 0 errors, 0 warnings.
- [ ] Responsive viewport check — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)