### PR TITLE
Add season coverage view (Phase 2)

### DIFF
--- a/app/pages/SeasonCoveragePage.tsx
+++ b/app/pages/SeasonCoveragePage.tsx
@@ -1,0 +1,151 @@
+import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import type { SeasonCoverage } from '~/services/seasons.server';
+
+type SeasonCoveragePageProps = {
+  coverage: SeasonCoverage;
+};
+
+function formatDate(value: Date | string | null): string {
+  if (!value) {
+    return '—';
+  }
+  return new Date(value).toLocaleDateString('fi-FI');
+}
+
+export default function SeasonCoveragePage({ coverage }: SeasonCoveragePageProps) {
+  const { t } = useTranslation();
+  const { season, totalSessions, perType, perSection } = coverage;
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <Link
+          to={`/seasons/${season.slug}`}
+          className="text-blue-600 hover:text-blue-800 mb-4 inline-flex items-center"
+        >
+          {t('seasons.backToSeasons')}
+        </Link>
+        <h1 className="mt-2 text-3xl font-bold">{t('coverage.title', { season: season.name })}</h1>
+        <p className="mt-1 text-gray-600">{t('coverage.subtitle', { count: totalSessions })}</p>
+      </div>
+
+      {totalSessions === 0 ? (
+        <div className="rounded border border-gray-200 bg-gray-50 p-8 text-center">
+          <p className="text-gray-700">{t('coverage.emptyState')}</p>
+        </div>
+      ) : (
+        <div className="space-y-10">
+          <section>
+            <h2 className="mb-3 text-xl font-semibold">{t('coverage.perTypeHeading')}</h2>
+            <div className="overflow-x-auto rounded border border-gray-200">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="py-2 px-3 text-left font-medium text-gray-700">
+                      {t('coverage.colType')}
+                    </th>
+                    <th className="py-2 px-3 text-right font-medium text-gray-700">
+                      {t('coverage.colAppearances')}
+                    </th>
+                    <th className="py-2 px-3 text-right font-medium text-gray-700">
+                      {t('coverage.colUniqueDrills')}
+                    </th>
+                    <th className="py-2 px-3 text-right font-medium text-gray-700">
+                      {t('coverage.colTypeOnly')}
+                    </th>
+                    <th className="py-2 px-3 text-left font-medium text-gray-700">
+                      {t('coverage.colLastSeen')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {perType.map(type => (
+                    <tr
+                      key={type.id}
+                      className={`border-t ${type.appearances === 0 ? 'text-gray-400' : ''}`}
+                    >
+                      <td className="py-2 px-3">
+                        {type.name}
+                        {type.appearances === 0 && (
+                          <span className="ml-2 inline-block rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
+                            {t('coverage.neverUsed')}
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-right">{type.appearances}</td>
+                      <td className="py-2 px-3 text-right">{type.uniqueExerciseCount}</td>
+                      <td className="py-2 px-3 text-right">{type.fallbackOnlyCount}</td>
+                      <td className="py-2 px-3">{formatDate(type.lastSeen)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-xl font-semibold">{t('coverage.perSectionHeading')}</h2>
+            <div className="space-y-4">
+              {perSection.map(section => {
+                const usedCount = section.types.filter(t => t.appearances > 0).length;
+                const totalEligible = section.types.length;
+                return (
+                  <div key={section.id} className="rounded border border-gray-200 overflow-hidden">
+                    <div className="bg-gray-50 px-3 py-2 flex items-center justify-between">
+                      <h3 className="font-semibold">{section.name}</h3>
+                      <span className="text-xs text-gray-600">
+                        {t('coverage.sectionCoverageRatio', {
+                          used: usedCount,
+                          total: totalEligible,
+                        })}
+                      </span>
+                    </div>
+                    {section.types.length === 0 ? (
+                      <p className="p-3 text-sm text-gray-500">{t('coverage.noEligibleTypes')}</p>
+                    ) : (
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b">
+                            <th className="py-2 px-3 text-left font-medium text-gray-700">
+                              {t('coverage.colType')}
+                            </th>
+                            <th className="py-2 px-3 text-right font-medium text-gray-700">
+                              {t('coverage.colAppearances')}
+                            </th>
+                            <th className="py-2 px-3 text-left font-medium text-gray-700">
+                              {t('coverage.colLastSeen')}
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {section.types.map(type => (
+                            <tr
+                              key={type.id}
+                              className={`border-t ${type.appearances === 0 ? 'text-gray-400' : ''}`}
+                            >
+                              <td className="py-2 px-3">
+                                {type.name}
+                                {type.appearances === 0 && (
+                                  <span className="ml-2 inline-block rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
+                                    {t('coverage.neverUsed')}
+                                  </span>
+                                )}
+                              </td>
+                              <td className="py-2 px-3 text-right">{type.appearances}</td>
+                              <td className="py-2 px-3">{formatDate(type.lastSeen)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/pages/SeasonDetailPage.tsx
+++ b/app/pages/SeasonDetailPage.tsx
@@ -119,14 +119,22 @@ export default function SeasonDetailPage({ season }: SeasonDetailPageProps) {
       )}
 
       <div>
-        <div className="mb-3 flex items-center justify-between">
+        <div className="mb-3 flex items-center justify-between gap-3 flex-wrap">
           <h2 className="text-xl font-semibold">{t('seasons.practiceSessions')}</h2>
-          <Link
-            to={`/seasons/${season.slug}/add-sessions`}
-            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            {t('addSessions.cta')}
-          </Link>
+          <div className="flex items-center gap-2">
+            <Link
+              to={`/seasons/${season.slug}/coverage`}
+              className="inline-flex items-center rounded border border-gray-300 px-3 py-2 text-sm font-medium hover:bg-gray-50"
+            >
+              {t('coverage.cta')}
+            </Link>
+            <Link
+              to={`/seasons/${season.slug}/add-sessions`}
+              className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              {t('addSessions.cta')}
+            </Link>
+          </div>
         </div>
         {season.practiceSessions.length === 0 ? (
           <p className="text-gray-500">{t('seasons.noPracticeSessions')}</p>

--- a/app/repositories/season.server.ts
+++ b/app/repositories/season.server.ts
@@ -74,6 +74,43 @@ export async function findSeasonBySlug(slug: string) {
   });
 }
 
+export async function findSeasonBySlugWithCoverage(slug: string, language: string) {
+  return db.season.findUnique({
+    where: { slug },
+    include: {
+      practiceSessions: {
+        orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          scheduledAt: true,
+          sectionItems: {
+            select: {
+              sectionId: true,
+              exerciseTypeId: true,
+              exerciseId: true,
+              exerciseType: {
+                select: {
+                  id: true,
+                  slug: true,
+                  translations: {
+                    where: { language },
+                    select: { name: true },
+                  },
+                },
+              },
+              exercise: {
+                select: { id: true, slug: true, name: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
 export async function updateSeason(id: string, data: UpdateSeasonData) {
   return db.season.update({
     where: { id },

--- a/app/routes/seasons.$slug_.coverage.tsx
+++ b/app/routes/seasons.$slug_.coverage.tsx
@@ -1,0 +1,25 @@
+import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
+import { useLoaderData } from 'react-router';
+import SeasonCoveragePage from '~/pages/SeasonCoveragePage';
+import { fetchSeasonCoverage } from '~/services/seasons.server';
+import { getDefaultLocale } from '~/utils/locale.server';
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data?.coverage) {
+    return [{ title: 'Season Not Found - Harkkapankki' }];
+  }
+  return [{ title: `Coverage — ${data.coverage.season.name} - Harkkapankki` }];
+};
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const coverage = await fetchSeasonCoverage(params.slug!, getDefaultLocale());
+  if (!coverage) {
+    throw new Response('Season not found', { status: 404 });
+  }
+  return { coverage };
+}
+
+export default function SeasonCoverageRoute() {
+  const { coverage } = useLoaderData<typeof loader>();
+  return <SeasonCoveragePage coverage={coverage} />;
+}

--- a/app/services/seasons.server.ts
+++ b/app/services/seasons.server.ts
@@ -66,6 +66,165 @@ export async function fetchSeasonById(id: string) {
   return seasonRepo.findSeasonById(id);
 }
 
+type CoverageTypeRow = {
+  id: string;
+  name: string;
+  appearances: number;
+  lastSeen: Date | null;
+  fallbackOnlyCount: number;
+  uniqueExerciseCount: number;
+};
+
+type CoverageSectionRow = {
+  id: string;
+  name: string;
+  order: number;
+  types: Array<{
+    id: string;
+    name: string;
+    appearances: number;
+    lastSeen: Date | null;
+  }>;
+};
+
+export type SeasonCoverage = {
+  season: { slug: string; name: string };
+  totalSessions: number;
+  perType: CoverageTypeRow[];
+  perSection: CoverageSectionRow[];
+};
+
+export async function fetchSeasonCoverage(
+  slug: string,
+  language: string
+): Promise<SeasonCoverage | null> {
+  const [season, sections] = await Promise.all([
+    seasonRepo.findSeasonBySlugWithCoverage(slug, language),
+    sectionRepo.findAllSectionsWithDetails(language),
+  ]);
+  if (!season) {
+    return null;
+  }
+
+  type Aggregate = {
+    id: string;
+    name: string;
+    appearances: number;
+    lastSeen: Date | null;
+    fallbackOnlyCount: number;
+    exerciseIds: Set<string>;
+  };
+
+  const perTypeMap = new Map<string, Aggregate>();
+  const perSectionTypeMap = new Map<
+    string,
+    Map<string, { id: string; name: string; appearances: number; lastSeen: Date | null }>
+  >();
+
+  for (const section of sections) {
+    const inner = new Map<
+      string,
+      { id: string; name: string; appearances: number; lastSeen: Date | null }
+    >();
+    for (const type of section.exerciseTypes) {
+      inner.set(type.id, { id: type.id, name: type.name, appearances: 0, lastSeen: null });
+    }
+    perSectionTypeMap.set(section.id, inner);
+  }
+
+  for (const session of season.practiceSessions) {
+    const sessionDate = session.scheduledAt;
+    for (const item of session.sectionItems) {
+      const typeName = item.exerciseType.translations[0]?.name ?? item.exerciseType.slug;
+      const existing = perTypeMap.get(item.exerciseTypeId);
+      if (existing) {
+        existing.appearances += 1;
+        if (sessionDate && (!existing.lastSeen || sessionDate > existing.lastSeen)) {
+          existing.lastSeen = sessionDate;
+        }
+        if (item.exerciseId === null) {
+          existing.fallbackOnlyCount += 1;
+        } else {
+          existing.exerciseIds.add(item.exerciseId);
+        }
+      } else {
+        perTypeMap.set(item.exerciseTypeId, {
+          id: item.exerciseTypeId,
+          name: typeName,
+          appearances: 1,
+          lastSeen: sessionDate,
+          fallbackOnlyCount: item.exerciseId === null ? 1 : 0,
+          exerciseIds: new Set(item.exerciseId === null ? [] : [item.exerciseId]),
+        });
+      }
+
+      const sectionRow = perSectionTypeMap.get(item.sectionId);
+      if (sectionRow) {
+        const typeRow = sectionRow.get(item.exerciseTypeId);
+        if (typeRow) {
+          typeRow.appearances += 1;
+          if (sessionDate && (!typeRow.lastSeen || sessionDate > typeRow.lastSeen)) {
+            typeRow.lastSeen = sessionDate;
+          }
+        }
+      }
+    }
+  }
+
+  for (const section of sections) {
+    for (const type of section.exerciseTypes) {
+      if (!perTypeMap.has(type.id)) {
+        perTypeMap.set(type.id, {
+          id: type.id,
+          name: type.name,
+          appearances: 0,
+          lastSeen: null,
+          fallbackOnlyCount: 0,
+          exerciseIds: new Set<string>(),
+        });
+      }
+    }
+  }
+
+  const perType: CoverageTypeRow[] = Array.from(perTypeMap.values())
+    .map(t => ({
+      id: t.id,
+      name: t.name,
+      appearances: t.appearances,
+      lastSeen: t.lastSeen,
+      fallbackOnlyCount: t.fallbackOnlyCount,
+      uniqueExerciseCount: t.exerciseIds.size,
+    }))
+    .sort((a, b) => {
+      if (a.appearances !== b.appearances) {
+        return b.appearances - a.appearances;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+  const perSection: CoverageSectionRow[] = sections
+    .map(section => {
+      const inner = perSectionTypeMap.get(section.id);
+      const types = inner
+        ? Array.from(inner.values()).sort((a, b) => {
+            if (a.appearances !== b.appearances) {
+              return b.appearances - a.appearances;
+            }
+            return a.name.localeCompare(b.name);
+          })
+        : [];
+      return { id: section.id, name: section.name, order: section.order, types };
+    })
+    .sort((a, b) => a.order - b.order);
+
+  return {
+    season: { slug: season.slug, name: season.name },
+    totalSessions: season.practiceSessions.length,
+    perType,
+    perSection,
+  };
+}
+
 type SectionsWithDetails = Awaited<ReturnType<typeof sectionRepo.findAllSectionsWithDetails>>;
 
 export async function fetchAddSessionsContext(slug: string, language: string) {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -139,6 +139,23 @@
       "7": "Sunday"
     }
   },
+  "coverage": {
+    "title": "Coverage — {{season}}",
+    "subtitle_one": "Based on {{count}} session",
+    "subtitle_other": "Based on {{count}} sessions",
+    "emptyState": "This season has no practice sessions yet. Add sessions and coverage stats will appear here.",
+    "perTypeHeading": "Exercise type usage",
+    "perSectionHeading": "By section",
+    "colType": "Type",
+    "colAppearances": "Appearances",
+    "colUniqueDrills": "Unique drills",
+    "colTypeOnly": "Type-only",
+    "colLastSeen": "Last seen",
+    "neverUsed": "Never used",
+    "noEligibleTypes": "No exercise types are linked to this section.",
+    "sectionCoverageRatio": "{{used}}/{{total}} used",
+    "cta": "Coverage"
+  },
   "addSessions": {
     "title": "Add practice sessions",
     "subtitle": "Generate one or more practice sessions for season \"{{season}}\"",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -139,6 +139,23 @@
       "7": "Sunnuntai"
     }
   },
+  "coverage": {
+    "title": "Kattavuus — {{season}}",
+    "subtitle_one": "{{count}} harjoituskerran perusteella",
+    "subtitle_other": "{{count}} harjoituskerran perusteella",
+    "emptyState": "Tällä kaudella ei ole vielä harjoituskertoja. Lisää harjoituskertoja ja kattavuus näkyy täällä.",
+    "perTypeHeading": "Harjoitustyyppien käyttö",
+    "perSectionHeading": "Osioittain",
+    "colType": "Tyyppi",
+    "colAppearances": "Esiintymät",
+    "colUniqueDrills": "Eri harjoitukset",
+    "colTypeOnly": "Vain tyyppi",
+    "colLastSeen": "Viimeksi",
+    "neverUsed": "Ei käytössä",
+    "noEligibleTypes": "Tähän osioon ei ole liitetty yhtään harjoitustyyppiä.",
+    "sectionCoverageRatio": "{{used}}/{{total}} käytössä",
+    "cta": "Kattavuus"
+  },
   "addSessions": {
     "title": "Lisää harjoituskertoja",
     "subtitle": "Generoi yksi tai useampi harjoituskerta kaudelle \"{{season}}\"",


### PR DESCRIPTION
## Summary
Phase 2 of the season-planning feature: a read-only coverage view per season.

- New route `/seasons/$slug/coverage` accessible via a "Kattavuus" CTA on the season detail page.
- **Per-type table** (top): each exercise type eligible in the season's sections — appearances, unique specific drills used, type-only fallback count, last-seen date. Never-used types get an amber "Ei käytössä" badge.
- **Per-section blocks** (below): one card per fixed section showing `used / total` ratio in the header and a table of every eligible type with appearances + last-seen.
- Empty state when the season has no sessions yet ("Lisää harjoituskertoja…").
- FI + EN i18n.

No suggestions yet — just visibility, per the Phase 2 plan.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --write` — clean.
- [x] `vitest tests/sessionAutoGenerator.test.ts` — still passing (untouched).
- [x] Browser sweep:
  - New season → coverage page shows "0 harjoituskerran perusteella" + empty-state message.
  - Generated 3 sessions via auto-gen (which produced 7 type-only fallbacks).
  - Coverage page now shows: 10 used types with correct counts, last-seen dates, type-only counts; 3 never-used types flagged. Per-section ratios match expectations (Alku 2/2, Alkulämmittely 2/3, Pelit 2/3, Tekniikka 3/4, Lopetus 1/1).
  - Console: 0 errors, 0 warnings.
- [ ] Responsive viewport check — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)