### PR TITLE
Add season hints (Phase 3)

### DIFF
--- a/app/pages/SeasonCoveragePage.tsx
+++ b/app/pages/SeasonCoveragePage.tsx
@@ -36,6 +36,61 @@ export default function SeasonCoveragePage({ coverage }: SeasonCoveragePageProps
         </div>
       ) : (
         <div className="space-y-10">
+          {(coverage.hints.staleTypes.length > 0 ||
+            coverage.hints.recentRepeats.length > 0 ||
+            coverage.hints.lowDiversitySections.length > 0) && (
+            <section className="rounded border border-amber-300 bg-amber-50 p-4">
+              <h2 className="mb-3 text-xl font-semibold text-amber-900">{t('hints.heading')}</h2>
+              <div className="space-y-4 text-sm text-amber-900">
+                {coverage.hints.staleTypes.length > 0 && (
+                  <div>
+                    <h3 className="font-semibold">{t('hints.staleHeading')}</h3>
+                    <ul className="mt-1 list-disc list-inside">
+                      {coverage.hints.staleTypes.map(hint => (
+                        <li key={hint.typeId}>
+                          {t('hints.staleItem', {
+                            name: hint.typeName,
+                            count: hint.sessionsSinceLastUse,
+                          })}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {coverage.hints.recentRepeats.length > 0 && (
+                  <div>
+                    <h3 className="font-semibold">{t('hints.repeatHeading')}</h3>
+                    <ul className="mt-1 list-disc list-inside">
+                      {coverage.hints.recentRepeats.map((hint, idx) => (
+                        <li key={`${hint.exerciseId}-${idx}`}>
+                          {t('hints.repeatItem', {
+                            name: hint.exerciseName,
+                            gap: hint.gap,
+                          })}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {coverage.hints.lowDiversitySections.length > 0 && (
+                  <div>
+                    <h3 className="font-semibold">{t('hints.diversityHeading')}</h3>
+                    <ul className="mt-1 list-disc list-inside">
+                      {coverage.hints.lowDiversitySections.map(hint => (
+                        <li key={hint.sectionId}>
+                          {t('hints.diversityItem', {
+                            section: hint.sectionName,
+                            type: hint.uniqueTypeName,
+                            count: hint.sessionsInSection,
+                          })}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </section>
+          )}
           <section>
             <h2 className="mb-3 text-xl font-semibold">{t('coverage.perTypeHeading')}</h2>
             <div className="overflow-x-auto rounded border border-gray-200">

--- a/app/pages/SeasonDetailPage.tsx
+++ b/app/pages/SeasonDetailPage.tsx
@@ -2,6 +2,7 @@ import { Form, Link, useNavigation, useSearchParams } from 'react-router';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '~/components/Button';
+import type { SeasonHints } from '~/services/seasonHints.server';
 
 type SeasonPracticeSession = {
   id: string;
@@ -28,15 +29,19 @@ type SeasonDetailData = {
 
 type SeasonDetailPageProps = {
   season: SeasonDetailData;
+  hints: SeasonHints | null;
 };
 
-export default function SeasonDetailPage({ season }: SeasonDetailPageProps) {
+export default function SeasonDetailPage({ season, hints }: SeasonDetailPageProps) {
   const { t } = useTranslation();
   const navigation = useNavigation();
   const [searchParams] = useSearchParams();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   const warningCount = Number(searchParams.get('warnings') ?? '0');
+  const totalHints = hints
+    ? hints.staleTypes.length + hints.recentRepeats.length + hints.lowDiversitySections.length
+    : 0;
   const isDeleting = navigation.state !== 'idle' && navigation.formData?.get('intent') === 'delete';
 
   const formatDate = (value: Date | string | null) =>
@@ -115,6 +120,18 @@ export default function SeasonDetailPage({ season }: SeasonDetailPageProps) {
           className="mb-4 rounded border border-amber-500 bg-amber-50 p-4 text-amber-900"
         >
           {t('addSessions.warningBanner', { count: warningCount })}
+        </div>
+      )}
+
+      {totalHints > 0 && (
+        <div className="mb-4 rounded border border-amber-300 bg-amber-50 p-4 text-amber-900 flex items-center justify-between gap-4">
+          <span>{t('hints.banner', { count: totalHints })}</span>
+          <Link
+            to={`/seasons/${season.slug}/coverage`}
+            className="font-semibold underline hover:text-amber-800 whitespace-nowrap"
+          >
+            {t('hints.bannerLink')}
+          </Link>
         </div>
       )}
 

--- a/app/routes/seasons.$slug.tsx
+++ b/app/routes/seasons.$slug.tsx
@@ -7,7 +7,8 @@ import {
 } from 'react-router';
 import { useLoaderData } from 'react-router';
 import SeasonDetailPage from '~/pages/SeasonDetailPage';
-import { deleteSeason, fetchSeasonBySlug } from '~/services/seasons.server';
+import { deleteSeason, fetchSeasonBySlug, fetchSeasonHints } from '~/services/seasons.server';
+import { getDefaultLocale } from '~/utils/locale.server';
 
 export const meta: MetaFunction<typeof loader> = ({ data: loaderData }) => {
   if (!loaderData?.season) {
@@ -17,11 +18,14 @@ export const meta: MetaFunction<typeof loader> = ({ data: loaderData }) => {
 };
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const season = await fetchSeasonBySlug(params.slug!);
+  const [season, hints] = await Promise.all([
+    fetchSeasonBySlug(params.slug!),
+    fetchSeasonHints(params.slug!, getDefaultLocale()),
+  ]);
   if (!season) {
     throw new Response('Season not found', { status: 404 });
   }
-  return { season };
+  return { season, hints };
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -51,6 +55,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export default function SeasonDetailRoute() {
-  const { season } = useLoaderData<typeof loader>();
-  return <SeasonDetailPage season={season} />;
+  const { season, hints } = useLoaderData<typeof loader>();
+  return <SeasonDetailPage season={season} hints={hints} />;
 }

--- a/app/services/seasonHints.server.ts
+++ b/app/services/seasonHints.server.ts
@@ -1,0 +1,157 @@
+type SectionItemInput = {
+  sectionId: string;
+  exerciseTypeId: string;
+  exerciseId: string | null;
+  typeName: string;
+  exerciseName: string | null;
+};
+
+type SessionInput = {
+  id: string;
+  slug: string;
+  scheduledAt: Date | null;
+  sectionItems: SectionItemInput[];
+};
+
+type SectionInput = {
+  id: string;
+  name: string;
+  eligibleTypeIds: string[];
+};
+
+export type ComputeHintsInput = {
+  sessions: SessionInput[];
+  sections: SectionInput[];
+};
+
+export type StaleTypeHint = {
+  typeId: string;
+  typeName: string;
+  sessionsSinceLastUse: number;
+};
+
+export type RecentRepeatHint = {
+  exerciseId: string;
+  exerciseName: string;
+  earlierSessionSlug: string;
+  laterSessionSlug: string;
+  gap: number;
+};
+
+export type LowDiversitySectionHint = {
+  sectionId: string;
+  sectionName: string;
+  uniqueTypeName: string;
+  sessionsInSection: number;
+};
+
+export type SeasonHints = {
+  staleTypes: StaleTypeHint[];
+  recentRepeats: RecentRepeatHint[];
+  lowDiversitySections: LowDiversitySectionHint[];
+};
+
+export const STALE_WINDOW = 3;
+export const REPEAT_WINDOW = 2;
+export const LOW_DIVERSITY_MIN_SESSIONS = 3;
+
+export function computeSeasonHints({ sessions, sections }: ComputeHintsInput): SeasonHints {
+  const totalSessions = sessions.length;
+
+  const staleTypes: StaleTypeHint[] = [];
+  if (totalSessions > STALE_WINDOW) {
+    const eligibleTypeIds = new Set<string>();
+    for (const section of sections) {
+      for (const id of section.eligibleTypeIds) {
+        eligibleTypeIds.add(id);
+      }
+    }
+
+    const lastUseIndexByType = new Map<string, { index: number; name: string }>();
+    sessions.forEach((session, index) => {
+      for (const item of session.sectionItems) {
+        if (!eligibleTypeIds.has(item.exerciseTypeId)) {
+          continue;
+        }
+        lastUseIndexByType.set(item.exerciseTypeId, { index, name: item.typeName });
+      }
+    });
+
+    const lastIndex = totalSessions - 1;
+    for (const [typeId, { index, name }] of lastUseIndexByType.entries()) {
+      const gap = lastIndex - index;
+      if (gap >= STALE_WINDOW) {
+        staleTypes.push({ typeId, typeName: name, sessionsSinceLastUse: gap });
+      }
+    }
+    staleTypes.sort((a, b) => b.sessionsSinceLastUse - a.sessionsSinceLastUse);
+  }
+
+  const recentRepeats: RecentRepeatHint[] = [];
+  type Seen = { sessionIndex: number; sessionSlug: string; exerciseName: string };
+  const seenByExercise = new Map<string, Seen>();
+  for (let i = 0; i < sessions.length; i++) {
+    const session = sessions[i];
+    for (const item of session.sectionItems) {
+      if (item.exerciseId === null || item.exerciseName === null) {
+        continue;
+      }
+      const previous = seenByExercise.get(item.exerciseId);
+      if (previous) {
+        const gap = i - previous.sessionIndex;
+        if (gap > 0 && gap <= REPEAT_WINDOW) {
+          recentRepeats.push({
+            exerciseId: item.exerciseId,
+            exerciseName: item.exerciseName,
+            earlierSessionSlug: previous.sessionSlug,
+            laterSessionSlug: session.slug,
+            gap,
+          });
+        }
+      }
+      seenByExercise.set(item.exerciseId, {
+        sessionIndex: i,
+        sessionSlug: session.slug,
+        exerciseName: item.exerciseName,
+      });
+    }
+  }
+
+  const lowDiversitySections: LowDiversitySectionHint[] = [];
+  for (const section of sections) {
+    if (section.eligibleTypeIds.length < 2) {
+      continue;
+    }
+
+    const typesUsedInSection = new Map<string, string>();
+    let sessionsInSection = 0;
+    for (const session of sessions) {
+      const itemsHere = session.sectionItems.filter(item => item.sectionId === section.id);
+      if (itemsHere.length === 0) {
+        continue;
+      }
+      sessionsInSection += 1;
+      for (const item of itemsHere) {
+        if (!typesUsedInSection.has(item.exerciseTypeId)) {
+          typesUsedInSection.set(item.exerciseTypeId, item.typeName);
+        }
+      }
+    }
+
+    if (sessionsInSection < LOW_DIVERSITY_MIN_SESSIONS) {
+      continue;
+    }
+
+    if (typesUsedInSection.size === 1) {
+      const [uniqueTypeName] = typesUsedInSection.values();
+      lowDiversitySections.push({
+        sectionId: section.id,
+        sectionName: section.name,
+        uniqueTypeName,
+        sessionsInSection,
+      });
+    }
+  }
+
+  return { staleTypes, recentRepeats, lowDiversitySections };
+}

--- a/app/services/seasons.server.ts
+++ b/app/services/seasons.server.ts
@@ -13,6 +13,7 @@ import {
   generateProgrammeForBatch,
   type GeneratorWarning,
 } from '~/services/sessionAutoGenerator.server';
+import { computeSeasonHints, type SeasonHints } from '~/services/seasonHints.server';
 
 export async function createSeason(input: SeasonFormData) {
   const baseSlug = slugify(input.name);
@@ -66,6 +67,38 @@ export async function fetchSeasonById(id: string) {
   return seasonRepo.findSeasonById(id);
 }
 
+export async function fetchSeasonHints(
+  slug: string,
+  language: string
+): Promise<SeasonHints | null> {
+  const [season, sections] = await Promise.all([
+    seasonRepo.findSeasonBySlugWithCoverage(slug, language),
+    sectionRepo.findAllSectionsWithDetails(language),
+  ]);
+  if (!season) {
+    return null;
+  }
+  return computeSeasonHints({
+    sessions: season.practiceSessions.map(session => ({
+      id: session.id,
+      slug: session.slug,
+      scheduledAt: session.scheduledAt,
+      sectionItems: session.sectionItems.map(item => ({
+        sectionId: item.sectionId,
+        exerciseTypeId: item.exerciseTypeId,
+        exerciseId: item.exerciseId,
+        typeName: item.exerciseType.translations[0]?.name ?? item.exerciseType.slug,
+        exerciseName: item.exercise?.name ?? null,
+      })),
+    })),
+    sections: sections.map(section => ({
+      id: section.id,
+      name: section.name,
+      eligibleTypeIds: section.exerciseTypes.map(t => t.id),
+    })),
+  });
+}
+
 type CoverageTypeRow = {
   id: string;
   name: string;
@@ -92,6 +125,7 @@ export type SeasonCoverage = {
   totalSessions: number;
   perType: CoverageTypeRow[];
   perSection: CoverageSectionRow[];
+  hints: SeasonHints;
 };
 
 export async function fetchSeasonCoverage(
@@ -217,11 +251,33 @@ export async function fetchSeasonCoverage(
     })
     .sort((a, b) => a.order - b.order);
 
+  const hintsInput = {
+    sessions: season.practiceSessions.map(session => ({
+      id: session.id,
+      slug: session.slug,
+      scheduledAt: session.scheduledAt,
+      sectionItems: session.sectionItems.map(item => ({
+        sectionId: item.sectionId,
+        exerciseTypeId: item.exerciseTypeId,
+        exerciseId: item.exerciseId,
+        typeName: item.exerciseType.translations[0]?.name ?? item.exerciseType.slug,
+        exerciseName: item.exercise?.name ?? null,
+      })),
+    })),
+    sections: sections.map(section => ({
+      id: section.id,
+      name: section.name,
+      eligibleTypeIds: section.exerciseTypes.map(t => t.id),
+    })),
+  };
+  const hints = computeSeasonHints(hintsInput);
+
   return {
     season: { slug: season.slug, name: season.name },
     totalSessions: season.practiceSessions.length,
     perType,
     perSection,
+    hints,
   };
 }
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -139,6 +139,19 @@
       "7": "Sunday"
     }
   },
+  "hints": {
+    "banner_one": "{{count}} hint for season planning.",
+    "banner_other": "{{count}} hints for season planning.",
+    "bannerLink": "Open coverage",
+    "heading": "Hints",
+    "staleHeading": "Types not seen in a while",
+    "staleItem": "{{name}} — {{count}} sessions since last use.",
+    "repeatHeading": "Recently repeated drills",
+    "repeatItem_one": "{{name}} appeared in back-to-back sessions (gap {{gap}}).",
+    "repeatItem_other": "{{name}} reappeared within {{gap}} sessions.",
+    "diversityHeading": "Sections lacking variety",
+    "diversityItem": "Section \"{{section}}\" used only \"{{type}}\" across {{count}} sessions."
+  },
   "coverage": {
     "title": "Coverage — {{season}}",
     "subtitle_one": "Based on {{count}} session",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -139,6 +139,19 @@
       "7": "Sunnuntai"
     }
   },
+  "hints": {
+    "banner_one": "{{count}} vinkki kauden suunnitteluun.",
+    "banner_other": "{{count}} vinkkiä kauden suunnitteluun.",
+    "bannerLink": "Avaa kattavuus",
+    "heading": "Vinkit",
+    "staleHeading": "Tyyppejä, joita ei ole näkynyt aikoihin",
+    "staleItem": "{{name}} — viimeisimmästä esiintymästä on {{count}} harjoituskertaa.",
+    "repeatHeading": "Saman harjoituksen toistoja",
+    "repeatItem_one": "{{name}} esiintyi peräkkäisissä harjoituksissa (väli {{gap}}).",
+    "repeatItem_other": "{{name}} esiintyi {{gap}} harjoituksen sisällä.",
+    "diversityHeading": "Yksipuoliset osiot",
+    "diversityItem": "Osio \"{{section}}\" käytti vain tyyppiä \"{{type}}\" {{count}} harjoituksen ajan."
+  },
   "coverage": {
     "title": "Kattavuus — {{season}}",
     "subtitle_one": "{{count}} harjoituskerran perusteella",

--- a/tests/seasonHints.test.ts
+++ b/tests/seasonHints.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest';
+import { computeSeasonHints } from '~/services/seasonHints.server';
+
+const SECTIONS = [
+  {
+    id: 'sec-1',
+    name: 'Alku',
+    eligibleTypeIds: ['type-a', 'type-b'],
+  },
+  {
+    id: 'sec-2',
+    name: 'Tekniikka',
+    eligibleTypeIds: ['type-c', 'type-d'],
+  },
+];
+
+function makeSession(
+  index: number,
+  items: Array<{
+    sectionId: string;
+    exerciseTypeId: string;
+    exerciseId: string | null;
+    typeName: string;
+    exerciseName: string | null;
+  }>
+) {
+  return {
+    id: `session-${index}`,
+    slug: `slug-${index}`,
+    scheduledAt: null,
+    sectionItems: items,
+  };
+}
+
+describe('computeSeasonHints', () => {
+  it('returns no hints when there are no sessions', () => {
+    const hints = computeSeasonHints({ sessions: [], sections: SECTIONS });
+    expect(hints.staleTypes).toEqual([]);
+    expect(hints.recentRepeats).toEqual([]);
+    expect(hints.lowDiversitySections).toEqual([]);
+  });
+
+  it('does not flag stale types when total sessions <= STALE_WINDOW', () => {
+    const sessions = [0, 1, 2].map(i =>
+      makeSession(i, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: 'ex-1',
+          typeName: 'Alkukäyntö',
+          exerciseName: 'Drill 1',
+        },
+      ])
+    );
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.staleTypes).toEqual([]);
+  });
+
+  it('flags a type that was used once and missed for the last 3 sessions', () => {
+    const sessions = [
+      makeSession(0, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: 'ex-a',
+          typeName: 'A-tyyppi',
+          exerciseName: 'A drill',
+        },
+      ]),
+      makeSession(1, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-b',
+          exerciseId: 'ex-b',
+          typeName: 'B-tyyppi',
+          exerciseName: 'B drill',
+        },
+      ]),
+      makeSession(2, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-b',
+          exerciseId: 'ex-b2',
+          typeName: 'B-tyyppi',
+          exerciseName: 'B drill 2',
+        },
+      ]),
+      makeSession(3, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-b',
+          exerciseId: 'ex-b3',
+          typeName: 'B-tyyppi',
+          exerciseName: 'B drill 3',
+        },
+      ]),
+    ];
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.staleTypes).toHaveLength(1);
+    expect(hints.staleTypes[0]).toMatchObject({
+      typeId: 'type-a',
+      typeName: 'A-tyyppi',
+      sessionsSinceLastUse: 3,
+    });
+  });
+
+  it('detects a specific exercise repeated within the 2-session window', () => {
+    const sessions = [
+      makeSession(0, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: 'ex-1',
+          typeName: 'A',
+          exerciseName: 'Drill 1',
+        },
+      ]),
+      makeSession(1, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: 'ex-1',
+          typeName: 'A',
+          exerciseName: 'Drill 1',
+        },
+      ]),
+    ];
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.recentRepeats).toHaveLength(1);
+    expect(hints.recentRepeats[0]).toMatchObject({
+      exerciseId: 'ex-1',
+      gap: 1,
+      earlierSessionSlug: 'slug-0',
+      laterSessionSlug: 'slug-1',
+    });
+  });
+
+  it('does not flag the same exercise reappearing outside the repeat window', () => {
+    const sessions = [
+      makeSession(0, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: 'ex-1',
+          typeName: 'A',
+          exerciseName: 'Drill 1',
+        },
+      ]),
+      makeSession(1, []),
+      makeSession(2, []),
+      makeSession(3, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: 'ex-1',
+          typeName: 'A',
+          exerciseName: 'Drill 1',
+        },
+      ]),
+    ];
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.recentRepeats).toEqual([]);
+  });
+
+  it('ignores type-only fallbacks (exerciseId=null) for the repeat rule', () => {
+    const sessions = [
+      makeSession(0, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: null,
+          typeName: 'A',
+          exerciseName: null,
+        },
+      ]),
+      makeSession(1, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: null,
+          typeName: 'A',
+          exerciseName: null,
+        },
+      ]),
+    ];
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.recentRepeats).toEqual([]);
+  });
+
+  it('flags a section using only one type after enough sessions', () => {
+    const sessions = [0, 1, 2, 3].map(i =>
+      makeSession(i, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: `ex-${i}`,
+          typeName: 'A-tyyppi',
+          exerciseName: `Drill ${i}`,
+        },
+        {
+          sectionId: 'sec-2',
+          exerciseTypeId: i % 2 === 0 ? 'type-c' : 'type-d',
+          exerciseId: `ex-c-${i}`,
+          typeName: i % 2 === 0 ? 'C-tyyppi' : 'D-tyyppi',
+          exerciseName: `Drill ${i}`,
+        },
+      ])
+    );
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.lowDiversitySections).toHaveLength(1);
+    expect(hints.lowDiversitySections[0]).toMatchObject({
+      sectionId: 'sec-1',
+      uniqueTypeName: 'A-tyyppi',
+      sessionsInSection: 4,
+    });
+  });
+
+  it('does not flag low diversity for sections with fewer than 3 sessions', () => {
+    const sessions = [0, 1].map(i =>
+      makeSession(i, [
+        {
+          sectionId: 'sec-1',
+          exerciseTypeId: 'type-a',
+          exerciseId: `ex-${i}`,
+          typeName: 'A',
+          exerciseName: `Drill ${i}`,
+        },
+      ])
+    );
+    const hints = computeSeasonHints({ sessions, sections: SECTIONS });
+    expect(hints.lowDiversitySections).toEqual([]);
+  });
+
+  it('does not flag low diversity for sections with only one eligible type', () => {
+    const sessions = [0, 1, 2, 3].map(i =>
+      makeSession(i, [
+        {
+          sectionId: 'solo',
+          exerciseTypeId: 'only',
+          exerciseId: `ex-${i}`,
+          typeName: 'Only',
+          exerciseName: `Drill ${i}`,
+        },
+      ])
+    );
+    const hints = computeSeasonHints({
+      sessions,
+      sections: [{ id: 'solo', name: 'Solo', eligibleTypeIds: ['only'] }],
+    });
+    expect(hints.lowDiversitySections).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 3 of the season-planning feature: read-only smart suggestions. No enforcement, no autofix.

Three rules, all surfaced via a pure `computeSeasonHints` function in `app/services/seasonHints.server.ts`:

1. **Stale type** — eligible types not appearing in the last 3 sessions, once the season has more than 3 sessions.
2. **Recent repeat** — a specific exercise (with `exerciseId`) reappears within 2 sessions of itself. Type-only fallback items are ignored. Catches violations of the auto-gen's rolling window introduced by manual edits.
3. **Low-diversity section** — a section with ≥2 eligible types has used only one type across ≥3 of its sessions.

**Surfaces:**
- Compact amber banner on the season detail page ("N vinkkiä kauden suunnitteluun") linking to coverage.
- Dedicated "Vinkit" section at the top of the coverage page, grouped by rule, hidden when zero hints fire.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --write` — clean.
- [x] `vitest` — 84/84 passing (9 new for the hints engine: empty season, sub-window, stale, repeat-within-window, repeat-outside-window, type-only ignored, low-diversity, low-diversity sub-threshold, single-eligible-type ignore).
- [x] Browser sweep:
  - Empty season: no banner, no hints section.
  - Created Vinkkitesti, generated 6 sessions via auto-gen.
  - Detail banner: "1 vinkki kauden suunnitteluun. Avaa kattavuus".
  - Coverage page: "Vinkit > Tyyppejä, joita ei ole näkynyt aikoihin > OB-säännöt — viimeisimmästä esiintymästä on 5 harjoituskertaa".
  - Console: 0 errors, 0 warnings.
- [ ] Responsive viewport check — deferred.

## Why this shape
Thresholds match the Phase 1 auto-gen contract: the rolling 2-row exclusion in `generateProgrammeForBatch` plus a 1-session buffer, so coaches get flagged when manual edits violate the same invariants the algorithm enforces during generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)