### PR TITLE
Render styled 404 page via root ErrorBoundary

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -18,13 +18,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                   to="/exercises"
                   className="text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md"
                 >
-                  {t('navigation.exercises')}
+                  {t('navigation.exercises', 'Harjoitukset')}
                 </Link>
                 <Link
                   to="/practise-sessions"
                   className="text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md"
                 >
-                  {t('navigation.sessions')}
+                  {t('navigation.sessions', 'Harjoituskerrat')}
                 </Link>
               </div>
             </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,15 @@
 import type { LinksFunction, LoaderFunctionArgs } from 'react-router';
-import { Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from 'react-router';
+import {
+  Link,
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  isRouteErrorResponse,
+  useLoaderData,
+  useRouteError,
+} from 'react-router';
 import tailwindStyles from './styles/tailwind.css?url';
 import { useChangeLanguage } from 'remix-i18next/react';
 import { i18next } from './i18n.server';
@@ -78,6 +88,65 @@ export default function App() {
   return (
     <AppLayout>
       <Outlet />
+    </AppLayout>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <AppLayout>
+        <div className="mx-auto max-w-2xl p-6 text-center">
+          <p className="text-sm font-semibold text-blue-600">404</p>
+          <h1 className="mt-2 text-3xl font-bold text-gray-900">Sivua ei löytynyt</h1>
+          <p className="mt-2 text-gray-600">
+            Etsimääsi sivua ei löytynyt. Linkki saattaa olla vanhentunut tai resurssi on poistettu.
+          </p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Link
+              to="/"
+              className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+            >
+              Etusivulle
+            </Link>
+            <Link
+              to="/seasons"
+              className="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium hover:bg-gray-50"
+            >
+              Kaudet
+            </Link>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  const message =
+    isRouteErrorResponse(error) && typeof error.data === 'string'
+      ? error.data
+      : error instanceof Error
+        ? error.message
+        : 'Tapahtui odottamaton virhe.';
+
+  const status = isRouteErrorResponse(error) ? error.status : 500;
+
+  return (
+    <AppLayout>
+      <div className="mx-auto max-w-2xl p-6 text-center">
+        <p className="text-sm font-semibold text-red-600">{status}</p>
+        <h1 className="mt-2 text-3xl font-bold text-gray-900">Jokin meni pieleen</h1>
+        <p className="mt-2 text-gray-600">{message}</p>
+        <div className="mt-6 flex justify-center">
+          <Link
+            to="/"
+            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+          >
+            Etusivulle
+          </Link>
+        </div>
+      </div>
     </AppLayout>
   );
 }


### PR DESCRIPTION
## Summary
Replaces React Router's bare `<h1>404</h1>` with a branded page that keeps the site nav and offers links back to home and the seasons surface. Other thrown errors fall through to a generic "Jokin meni pieleen" view with the status code surfaced.

- `app/root.tsx` exports `ErrorBoundary`. It detects 404 via `isRouteErrorResponse` and renders a dedicated page; any other thrown error renders a generic error UI.
- `AppLayout` is rendered inside the boundary so nav stays visible.
- `app/components/Layout.tsx` now passes Finnish defaults to `t('navigation.exercises'…)` so top-level no-match URLs (where the root loader never runs and translations aren't loaded) don't show raw i18n keys.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Browser sweep:
  - `/seasons/does-not-exist` (loader throws 404) → 404 page renders with nav, headings in Finnish, working CTAs.
  - `/this-route-does-not-exist` (no matched route) → same 404 page; nav now shows "Harjoitukset" / "Harjoituskerrat" instead of raw i18n keys.
- Console error count for 404 routes is 1 (the expected resource-fetch 404 logged by the browser); no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)