### PR TITLE
Fix responsive layout breaks at narrow viewports

### DIFF
--- a/app/components/AddSessionsForm.tsx
+++ b/app/components/AddSessionsForm.tsx
@@ -189,7 +189,7 @@ export default function AddSessionsForm({
 
   return (
     <Form method="post" onSubmit={handleSubmit} noValidate>
-      <fieldset className="mb-6 rounded border border-gray-200 p-4">
+      <fieldset className="mb-6 rounded border border-gray-200 p-4 min-w-0">
         <legend className="px-2 text-lg font-semibold">{t('addSessions.section')}</legend>
 
         <div className="mb-4 flex flex-wrap items-end gap-4">

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -13,16 +13,16 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               <Link to="/" className="flex items-center">
                 <span className="text-xl font-bold">Harkkapankki</span>
               </Link>
-              <div className="ml-6 flex items-center space-x-4">
+              <div className="ml-2 sm:ml-6 flex items-center space-x-1 sm:space-x-4">
                 <Link
                   to="/exercises"
-                  className="text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md"
+                  className="text-gray-700 hover:text-gray-900 px-2 sm:px-3 py-2 rounded-md text-sm sm:text-base"
                 >
                   {t('navigation.exercises')}
                 </Link>
                 <Link
                   to="/practise-sessions"
-                  className="text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md"
+                  className="text-gray-700 hover:text-gray-900 px-2 sm:px-3 py-2 rounded-md text-sm sm:text-base"
                 >
                   {t('navigation.sessions')}
                 </Link>

--- a/app/components/SeasonForm.tsx
+++ b/app/components/SeasonForm.tsx
@@ -59,7 +59,7 @@ export default function SeasonForm({ defaults, errors, submitText, cancelHref }:
 
   return (
     <Form method="post" onSubmit={handleSubmit} noValidate>
-      <fieldset className="mb-6 rounded border border-gray-200 p-4">
+      <fieldset className="mb-6 rounded border border-gray-200 p-4 min-w-0">
         <legend className="px-2 text-lg font-semibold">{t('seasons.detailsSection')}</legend>
 
         <div className="mb-4">

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -126,7 +126,11 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
                   d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                 />
               </svg>
-              {t('sessions.scheduled')}: {new Date(session.scheduledAt).toLocaleString('fi-FI')}
+              {t('sessions.scheduled')}:{' '}
+              {new Date(session.scheduledAt).toLocaleString('fi-FI', {
+                dateStyle: 'short',
+                timeStyle: 'short',
+              })}
             </div>
           )}
         </div>

--- a/app/pages/SeasonDetailPage.tsx
+++ b/app/pages/SeasonDetailPage.tsx
@@ -59,9 +59,9 @@ export default function SeasonDetailPage({ season, hints }: SeasonDetailPageProp
         >
           {t('seasons.backToSeasons')}
         </Link>
-        <div className="flex justify-between items-start mt-2 gap-4">
+        <div className="flex flex-wrap justify-between items-start mt-2 gap-3">
           <h1 className="text-3xl font-bold">{season.name}</h1>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Link
               to={`/seasons/${season.slug}/edit`}
               className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"


### PR DESCRIPTION
## Summary
Three small layout fixes uncovered by a 375 / 768 / 1280 px sweep across all season pages and the home page.

| Issue | Fix |
| --- | --- |
| Navbar overflows at 375 px (brand + 2 links = ~429 px) | Tighten spacing on small widths: `ml-2 sm:ml-6`, `space-x-1 sm:space-x-4`, `px-2 sm:px-3`, `text-sm sm:text-base` |
| Season detail header (title + Edit/Delete buttons) spills 2 px past viewport | Add `flex-wrap` so the buttons wrap to a second row |
| `/seasons/$slug/add-sessions` and form pages overflow by ~120 px | Add `min-w-0` to the fieldsets — `<fieldset>` defaults to `min-width: min-content`, which let the inner table push the box wider than its parent and bypassed `overflow-x-auto` |

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Browser sweep at 375 / 768 / 1280 px across `/`, `/seasons`, `/seasons/new`, `/seasons/$slug`, `/seasons/$slug/edit`, `/seasons/$slug/add-sessions`, `/seasons/$slug/coverage`. All pages now report `scrollWidth === innerWidth` (no horizontal page scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)