### PR TITLE
Add Seasons link to main nav

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -8,23 +8,29 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <div className="min-h-screen bg-gray-50">
       <nav className="bg-white shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 py-3 sm:py-0 sm:h-16">
+            <div className="flex flex-wrap items-center">
               <Link to="/" className="flex items-center">
                 <span className="text-xl font-bold">Harkkapankki</span>
               </Link>
-              <div className="ml-2 sm:ml-6 flex items-center space-x-1 sm:space-x-4">
+              <div className="ml-2 sm:ml-6 flex flex-wrap items-center gap-x-1 sm:gap-x-4">
                 <Link
-                  to="/exercises"
+                  to="/seasons"
                   className="text-gray-700 hover:text-gray-900 px-2 sm:px-3 py-2 rounded-md text-sm sm:text-base"
                 >
-                  {t('navigation.exercises', 'Harjoitukset')}
+                  {t('navigation.seasons', 'Kaudet')}
                 </Link>
                 <Link
                   to="/practise-sessions"
                   className="text-gray-700 hover:text-gray-900 px-2 sm:px-3 py-2 rounded-md text-sm sm:text-base"
                 >
                   {t('navigation.sessions', 'Harjoituskerrat')}
+                </Link>
+                <Link
+                  to="/exercises"
+                  className="text-gray-700 hover:text-gray-900 px-2 sm:px-3 py-2 rounded-md text-sm sm:text-base"
+                >
+                  {t('navigation.exercises', 'Harjoitukset')}
                 </Link>
               </div>
             </div>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3,6 +3,7 @@
     "home": "Home",
     "exercises": "Exercises",
     "sessions": "Practice Sessions",
+    "seasons": "Seasons",
     "newExercise": "New Exercise",
     "newSession": "New Practice Session"
   },

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -3,6 +3,7 @@
     "home": "Etusivu",
     "exercises": "Harjoitukset",
     "sessions": "Harjoituskerrat",
+    "seasons": "Kaudet",
     "newExercise": "Uusi harjoitus",
     "newSession": "Uusi harjoituskerta"
   },


### PR DESCRIPTION
## Summary
Adds "Kaudet" / "Seasons" as the first nav item (before "Harjoituskerrat" and "Harjoitukset"), since the season-planning flow is now the main entry point.

The nav row gets `flex-wrap` so a third link doesn't reintroduce horizontal page scroll on narrow viewports. At 375 px the brand sits on row 1 with the three links stacked on row 2; at 768 px and above everything stays on one line.

i18n keys added: `navigation.seasons` in FI + EN.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Browser sweep at 375 px and 1280 px:
  - 375 px: brand on row 1, "Kaudet / Harjoituskerrat / Harjoitukset" on row 2; `scrollWidth === innerWidth`.
  - 1280 px: single row, "Harkkapankki  Kaudet  Harjoituskerrat  Harjoitukset".

🤖 Generated with [Claude Code](https://claude.com/claude-code)