### PR TITLE
Default-name auto-generated sessions "Kenttätreenit #N"

### DIFF
--- a/app/routes/seasons.$slug_.add-sessions.tsx
+++ b/app/routes/seasons.$slug_.add-sessions.tsx
@@ -45,6 +45,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     season: { id: ctx.season.id, slug: ctx.season.slug },
     sections: ctx.sections,
     rows: result.data.rows,
+    existingSessionCount: ctx.season.practiceSessions.length,
   });
 
   const params2 = new URLSearchParams();

--- a/app/services/seasons.server.ts
+++ b/app/services/seasons.server.ts
@@ -310,7 +310,10 @@ type CreateSessionsForSeasonInput = {
   season: { id: string; slug: string };
   sections: SectionsWithDetails;
   rows: AddSessionsRow[];
+  existingSessionCount: number;
 };
+
+const DEFAULT_SESSION_NAME_PREFIX = 'Kenttätreenit';
 
 export async function createSessionsForSeason(input: CreateSessionsForSeasonInput): Promise<{
   createdCount: number;
@@ -346,8 +349,10 @@ export async function createSessionsForSeason(input: CreateSessionsForSeasonInpu
       const row = input.rows[i];
       const scheduledAt = helsinkiWallClockToUtc(row.date, row.startTime);
       const sessionLength = diffMinutes(row);
+      const sessionNumber = input.existingSessionCount + i + 1;
       await queryCreatePracticeSessionTx(tx, {
         slug: finalSlugs[i],
+        name: `${DEFAULT_SESSION_NAME_PREFIX} #${sessionNumber}`,
         sessionLength,
         seasonId: input.season.id,
         scheduledAt,


### PR DESCRIPTION
## Summary
Auto-generated sessions previously had `name = null`, so the season detail and `/practise-sessions` lists rendered them as "Nimetön harjoituskerta". Now they get a sensible default name when the auto-gen writes them.

- Format: `Kenttätreenit #N` where N is the per-season session number.
- Numbering continues across batches: if a season already has 3 sessions and the coach adds 5 more, the new ones become `#4` … `#8`. Derived from `ctx.season.practiceSessions.length` in the loader and threaded into `createSessionsForSeason` as `existingSessionCount`.
- Coaches can still rename any session via the existing edit form — the default just gives them a starting point instead of "Untitled".

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Created a season, posted a 3-row batch + a 2-row batch, queried the DB:

  ```
  Kenttätreenit #1 | 2026-05-06
  Kenttätreenit #2 | 2026-05-13
  Kenttätreenit #3 | 2026-05-20
  Kenttätreenit #4 | 2026-05-27
  Kenttätreenit #5 | 2026-06-03
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)