### PR TITLE
Seed add-sessions rows from season start date even if it's in the past

### DIFF
--- a/app/components/AddSessionsForm.tsx
+++ b/app/components/AddSessionsForm.tsx
@@ -70,7 +70,7 @@ function buildInitialRows(count: number, season: SeasonDefaults): SessionRow[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const seasonStart = season.startDate ? new Date(season.startDate) : null;
-  const fromDate = seasonStart && seasonStart > today ? seasonStart : today;
+  const fromDate = seasonStart ?? today;
   let cursor = nextOccurrenceOfWeekday(fromDate, dayOfWeek);
 
   const rows: SessionRow[] = [];


### PR DESCRIPTION
## Summary
**Bug.** Coach creates a season starting 29.4.2026 (Wednesday), opens "Add sessions" with `defaultDayOfWeek = Wednesday`, and the first row seeds to **6.5.2026** instead of the season's start date. Past start dates were being silently swapped for "today" when computing the seed cursor, so any retroactive/journaling use case got broken seeds.

**Fix.** Drop the `seasonStart > today` guard. The seed cursor now respects the season's start date as-is; forward-planning seasons (start date in the future) flow through unchanged.

```diff
-  const fromDate = seasonStart && seasonStart > today ? seasonStart : today;
+  const fromDate = seasonStart ?? today;
```

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Reproduced the bug, applied the fix, navigated to `/seasons/paststarttest/add-sessions`. Date inputs now read:

  ```
  2026-04-29
  2026-05-06
  2026-05-13
  ```

  matching what the user expected for a Wednesday-starting season.

🤖 Generated with [Claude Code](https://claude.com/claude-code)