### PR TITLE
Warn when season start date is in the past

### DIFF
--- a/app/components/SeasonForm.tsx
+++ b/app/components/SeasonForm.tsx
@@ -57,6 +57,19 @@ export default function SeasonForm({ defaults, errors, submitText, cancelHref }:
 
   const fieldError = (field: string): string | undefined => clientErrors[field] ?? errors?.[field];
 
+  const startDateIsInPast = ((): boolean => {
+    if (!startDate) {
+      return false;
+    }
+    const parsed = new Date(startDate);
+    if (Number.isNaN(parsed.getTime())) {
+      return false;
+    }
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return parsed < today;
+  })();
+
   return (
     <Form method="post" onSubmit={handleSubmit} noValidate>
       <fieldset className="mb-6 rounded border border-gray-200 p-4 min-w-0">
@@ -115,6 +128,9 @@ export default function SeasonForm({ defaults, errors, submitText, cancelHref }:
             />
             {fieldError('startDate') && (
               <p className="mt-1 text-sm text-red-600">{fieldError('startDate')}</p>
+            )}
+            {!fieldError('startDate') && startDateIsInPast && (
+              <p className="mt-1 text-sm text-amber-700">{t('seasons.startDateInPast')}</p>
             )}
           </div>
           <div>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -116,6 +116,7 @@
     "startDateOptional": "Start date (optional)",
     "endDateOptional": "End date (optional)",
     "endDateAfterStartDate": "End date must be on or after start date",
+    "startDateInPast": "Start date is in the past — auto-generated sessions will start from the next future occurrence of the default weekday.",
     "defaultDayOfWeek": "Default day of week",
     "defaultStartTime": "Default start time",
     "defaultDuration": "Default duration",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -116,6 +116,7 @@
     "startDateOptional": "Alkupäivä (valinnainen)",
     "endDateOptional": "Loppupäivä (valinnainen)",
     "endDateAfterStartDate": "Loppupäivän tulee olla sama tai myöhempi kuin alkupäivän",
+    "startDateInPast": "Alkupäivä on menneisyydessä — automaattisesti generoidut harjoituskerrat alkavat seuraavasta tulevasta oletusviikonpäivästä.",
     "defaultDayOfWeek": "Oletus viikonpäivä",
     "defaultStartTime": "Oletus alkamisaika",
     "defaultDuration": "Oletuskesto",


### PR DESCRIPTION
## Summary
The add-sessions form intentionally seeds row #1 from the next future occurrence of the default weekday — i.e., it skips dates already in the past. That's correct behavior for forward planning, but it surprised at least one coach who entered a past start date (29.4) and got a first session dated 6.5 with no signal that the form was skipping ahead.

Add an inline amber warning under the start-date field on both the create and edit season forms whenever the entered date is before today. Informational only; doesn't block submission. The auto-gen behavior is unchanged.

FI + EN copy added under `seasons.startDateInPast`.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Browser sweep on `/seasons/new`:
  - Past date (29.4.2026 with today = 6.5.2026) → warning appears: "Alkupäivä on menneisyydessä — automaattisesti generoidut harjoituskerrat alkavat seuraavasta tulevasta oletusviikonpäivästä."
  - Future date (1.6.2026) → no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)