### PR TITLE
Pre-select Wed / 17:00 / 90min defaults on the new-season form

### DIFF
--- a/app/pages/NewSeasonPage.tsx
+++ b/app/pages/NewSeasonPage.tsx
@@ -30,7 +30,11 @@ export default function NewSeasonPage({ actionData }: NewSeasonPageProps) {
             ? Number(values.defaultDurationMin)
             : undefined,
       }
-    : undefined;
+    : {
+        defaultDayOfWeek: 3,
+        defaultStartTime: '17:00',
+        defaultDurationMin: 90,
+      };
 
   return (
     <div className="mx-auto max-w-4xl p-6">


### PR DESCRIPTION
## Summary
On a fresh `/seasons/new`, the three default-value selectors ("Oletus viikonpäivä" / "Oletus alkamisaika" / "Oletuskesto") were stuck at "Ei asetettu", forcing the coach to set them every time. Pre-select Wednesday, 17:00, and 90 min — the values the author uses for his own training sessions and the same defaults the original prototype seeded.

Scope:
- Only applies when the form has no submitted action data (i.e., true fresh render).
- If the user posts the form with errors, their previous selections — including explicit "Ei asetettu" — are preserved on re-render via `actionData.values`.
- The **edit** form is unaffected; it still mirrors whatever's saved on the season (verified with a season created with `NULL` defaults).

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier` — clean.
- [x] Browser sweep:
  - Fresh `/seasons/new` → `defaultDayOfWeek=3`, `defaultStartTime=17:00`, `defaultDurationMin=90`.
  - `/seasons/edittest/edit` for a season with NULL defaults → all three remain empty ("Ei asetettu").

🤖 Generated with [Claude Code](https://claude.com/claude-code)