### PR TITLE
Fix session section order to use Section.order

### DIFF
--- a/app/repositories/queryPracticeSessionById.server.ts
+++ b/app/repositories/queryPracticeSessionById.server.ts
@@ -8,7 +8,7 @@ export async function queryPracticeSessionById(id: string, language: string) {
         select: { slug: true, name: true },
       },
       sectionItems: {
-        orderBy: [{ sectionId: 'asc' }, { order: 'asc' }],
+        orderBy: [{ section: { order: 'asc' } }, { order: 'asc' }],
         include: {
           section: {
             include: {

--- a/app/repositories/queryPracticeSessionBySlug.server.ts
+++ b/app/repositories/queryPracticeSessionBySlug.server.ts
@@ -8,7 +8,7 @@ export async function queryPracticeSessionBySlug(slug: string, language: string)
         select: { slug: true, name: true },
       },
       sectionItems: {
-        orderBy: [{ sectionId: 'asc' }, { order: 'asc' }],
+        orderBy: [{ section: { order: 'asc' } }, { order: 'asc' }],
         include: {
           section: {
             include: {


### PR DESCRIPTION
## Summary
- Practice session detail queries ordered `sectionItems` by `sectionId` (a UUID), so sections appeared in effectively random order — e.g. Lopetus → Alkulämmittelyt → Alku → Pelit → Tekniikka instead of the intended sequence.
- Switched both `queryPracticeSessionBySlug` and `queryPracticeSessionById` to order by the related `Section.order` field, then by item `order` within the section.

## Test plan
- [ ] Open an existing session — sections appear as Alku → Alkulämmittelyt → Pelit → Tekniikka → Lopetus
- [ ] Open the edit form for the same session — items still listed in the correct section order
- [ ] Sessions with only some sections populated still render in correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)