### PR TITLE
Add side-panel exercise preview to practise session detail

### DIFF
--- a/app/components/ExercisePreviewPanel.tsx
+++ b/app/components/ExercisePreviewPanel.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import { Link, useFetcher } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import type MDEditor from '@uiw/react-md-editor';
+import { rehypeYouTube } from '~/utils/rehype-youtube';
+
+type PreviewExercise = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  content: string;
+  image?: string | null;
+  youtubeVideo?: string | null;
+  duration: number;
+  exerciseTypePath?: string | null;
+};
+
+type FetcherData = {
+  exercise: PreviewExercise;
+};
+
+type ExercisePreviewPanelProps = {
+  slug: string;
+  onClose: () => void;
+};
+
+export default function ExercisePreviewPanel({ slug, onClose }: ExercisePreviewPanelProps) {
+  const { t } = useTranslation();
+  const fetcher = useFetcher<FetcherData>();
+  const [MarkdownComponent, setMarkdownComponent] = useState<typeof MDEditor.Markdown | null>(null);
+
+  useEffect(() => {
+    import('@uiw/react-md-editor').then(mod => {
+      setMarkdownComponent(() => mod.default.Markdown);
+    });
+  }, []);
+
+  useEffect(() => {
+    fetcher.load(`/exercises/${slug}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
+
+  const isLoading = fetcher.state === 'loading' || (!fetcher.data && !fetcher.state);
+  const exercise = fetcher.data?.exercise;
+  const loadFailed = fetcher.state === 'idle' && !fetcher.data;
+
+  return (
+    <div className="border rounded-lg bg-white shadow-sm">
+      <div className="flex items-center justify-between p-4 border-b sticky top-0 bg-white rounded-t-lg">
+        <h2 className="text-lg font-semibold truncate pr-2">
+          {exercise?.name || t('common.loading')}
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('sessions.closePreview')}
+          className="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div className="p-4">
+        {isLoading && !exercise && <p className="text-gray-500">{t('common.loading')}</p>}
+
+        {loadFailed && !exercise && <p className="text-red-600">{t('exercises.notFound')}</p>}
+
+        {exercise && (
+          <>
+            {exercise.description && <p className="text-gray-600 mb-4">{exercise.description}</p>}
+
+            {exercise.image && (
+              <div className="mb-4">
+                <img
+                  src={exercise.image}
+                  alt={exercise.name}
+                  className="w-full rounded-md shadow object-cover"
+                />
+              </div>
+            )}
+
+            <div className="[&_ul]:list-disc [&_ul]:ml-6 [&_ol]:list-decimal [&_ol]:ml-6 [&_li]:mb-2">
+              {MarkdownComponent ? (
+                <MarkdownComponent source={exercise.content} rehypePlugins={[rehypeYouTube]} />
+              ) : (
+                <div className="whitespace-pre-line">{exercise.content}</div>
+              )}
+            </div>
+
+            <div className="mt-4 space-y-2 text-sm text-gray-500">
+              <div className="flex items-center">
+                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                {t('exercises.durationInMinutes', { duration: exercise.duration })}
+              </div>
+
+              {exercise.exerciseTypePath && (
+                <div className="flex items-center">
+                  <svg
+                    className="w-5 h-5 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z"
+                    />
+                  </svg>
+                  {t('exercises.type')}: {exercise.exerciseTypePath}
+                </div>
+              )}
+
+              {exercise.youtubeVideo && (
+                <a
+                  href={exercise.youtubeVideo}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:text-blue-800 flex items-center"
+                >
+                  <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+                  </svg>
+                  {t('exercises.watchTutorial')}
+                </a>
+              )}
+            </div>
+
+            <div className="mt-4 pt-4 border-t">
+              <Link
+                to={`/exercises/${exercise.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:text-blue-800 text-sm inline-flex items-center"
+              >
+                <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                  />
+                </svg>
+                {t('sessions.openInNewTab')}
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import ExercisePreviewPanel from '~/components/ExercisePreviewPanel';
 
 type SectionItem = {
   id: string;
@@ -40,11 +42,65 @@ type PractiseSessionDetailProps = {
   session: PracticeSessionData;
 };
 
+type ExerciseLinkProps = {
+  slug: string;
+  name: string;
+  className?: string;
+  onPreview: (slug: string) => void;
+  isActive: boolean;
+  previewLabel: string;
+};
+
+function ExerciseLink({
+  slug,
+  name,
+  className,
+  onPreview,
+  isActive,
+  previewLabel,
+}: ExerciseLinkProps) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <Link
+        to={`/exercises/${slug}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
+        {name}
+      </Link>
+      <button
+        type="button"
+        onClick={() => onPreview(slug)}
+        aria-label={previewLabel}
+        aria-pressed={isActive}
+        title={previewLabel}
+        className={`inline-flex items-center justify-center w-5 h-5 rounded text-gray-400 hover:text-blue-600 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+          isActive ? 'text-blue-600 bg-blue-50' : ''
+        }`}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V6zM14 4v16"
+          />
+        </svg>
+      </button>
+    </span>
+  );
+}
+
 export default function PractiseSessionDetail({ session }: PractiseSessionDetailProps) {
   const { t } = useTranslation();
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+
   const formatDate = (dateString: Date | string, locale: string = 'fi-FI') => {
     return new Date(dateString).toLocaleDateString(locale);
   };
+
+  const previewLabel = t('sessions.previewExercise');
 
   // Group items by section
   const itemsBySection = session.sectionItems.reduce(
@@ -144,103 +200,121 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
         </div>
       )}
 
-      {/* Sections */}
-      <div className="space-y-6">
-        <h2 className="text-xl font-semibold">{t('sessions.sessionPlan')}</h2>
-        {sections.length === 0 ? (
-          <p className="text-gray-500">{t('sessions.noExercisesAdded')}</p>
-        ) : (
-          sections.map(({ section, items }) => (
-            <div key={section.id} className="border rounded-lg p-4">
-              <h3 className="text-lg font-semibold mb-3">
-                {section.translations[0]?.name || section.slug}
-              </h3>
-              <ul className="space-y-2">
-                {(() => {
-                  // Group items by exercise type
-                  const groupedByType: Array<{
-                    typeName: string;
-                    items: SectionItem[];
-                  }> = [];
-                  for (const item of items) {
-                    const typeName =
-                      item.exerciseType.translations[0]?.name || item.exerciseType.id;
-                    const existing = groupedByType.find(g => g.typeName === typeName);
-                    if (existing) {
-                      existing.items.push(item);
-                    } else {
-                      groupedByType.push({ typeName, items: [item] });
-                    }
-                  }
+      {/* Two-column layout: session plan on left, optional exercise preview on right */}
+      <div className={selectedSlug ? 'flex flex-col lg:flex-row lg:gap-6' : ''}>
+        <div className={selectedSlug ? 'lg:w-1/2 lg:flex-shrink-0' : 'w-full'}>
+          <div className="space-y-6">
+            <h2 className="text-xl font-semibold">{t('sessions.sessionPlan')}</h2>
+            {sections.length === 0 ? (
+              <p className="text-gray-500">{t('sessions.noExercisesAdded')}</p>
+            ) : (
+              sections.map(({ section, items }) => (
+                <div key={section.id} className="border rounded-lg p-4">
+                  <h3 className="text-lg font-semibold mb-3">
+                    {section.translations[0]?.name || section.slug}
+                  </h3>
+                  <ul className="space-y-2">
+                    {(() => {
+                      // Group items by exercise type
+                      const groupedByType: Array<{
+                        typeName: string;
+                        items: SectionItem[];
+                      }> = [];
+                      for (const item of items) {
+                        const typeName =
+                          item.exerciseType.translations[0]?.name || item.exerciseType.id;
+                        const existing = groupedByType.find(g => g.typeName === typeName);
+                        if (existing) {
+                          existing.items.push(item);
+                        } else {
+                          groupedByType.push({ typeName, items: [item] });
+                        }
+                      }
 
-                  return groupedByType.map(group => {
-                    const exercisesInGroup = group.items.filter(i => i.exercise);
+                      return groupedByType.map(group => {
+                        const exercisesInGroup = group.items.filter(i => i.exercise);
 
-                    // No exercises linked - show type name only
-                    if (exercisesInGroup.length === 0) {
-                      return group.items.map(item => (
-                        <li key={item.id} className="flex items-start p-3 bg-gray-50 rounded-md">
-                          <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
-                            {item.order}
-                          </span>
-                          <span className="text-gray-700">{group.typeName}</span>
-                        </li>
-                      ));
-                    }
-
-                    // Single exercise with same name as type - show once
-                    if (
-                      exercisesInGroup.length === 1 &&
-                      exercisesInGroup[0].exercise!.name === group.typeName
-                    ) {
-                      return (
-                        <li
-                          key={exercisesInGroup[0].id}
-                          className="flex items-start p-3 bg-gray-50 rounded-md"
-                        >
-                          <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
-                            {exercisesInGroup[0].order}
-                          </span>
-                          <Link
-                            to={`/exercises/${exercisesInGroup[0].exercise!.slug}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue-600 hover:text-blue-800 hover:underline"
-                          >
-                            {group.typeName}
-                          </Link>
-                        </li>
-                      );
-                    }
-
-                    // Multiple exercises or single with different name - group under type
-                    return (
-                      <li key={group.typeName} className="p-3 bg-gray-50 rounded-md">
-                        <div className="font-medium text-gray-700 mb-2">{group.typeName}</div>
-                        <ul className="ml-4 space-y-1">
-                          {exercisesInGroup.map(item => (
-                            <li key={item.id} className="flex items-start">
-                              <span className="flex-shrink-0 w-5 h-5 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-xs font-medium mr-2">
+                        // No exercises linked - show type name only
+                        if (exercisesInGroup.length === 0) {
+                          return group.items.map(item => (
+                            <li
+                              key={item.id}
+                              className="flex items-start p-3 bg-gray-50 rounded-md"
+                            >
+                              <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
                                 {item.order}
                               </span>
-                              <Link
-                                to={`/exercises/${item.exercise!.slug}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:text-blue-800 hover:underline"
-                              >
-                                {item.exercise!.name}
-                              </Link>
+                              <span className="text-gray-700">{group.typeName}</span>
                             </li>
-                          ))}
-                        </ul>
-                      </li>
-                    );
-                  });
-                })()}
-              </ul>
-            </div>
-          ))
+                          ));
+                        }
+
+                        // Single exercise with same name as type - show once
+                        if (
+                          exercisesInGroup.length === 1 &&
+                          exercisesInGroup[0].exercise!.name === group.typeName
+                        ) {
+                          const single = exercisesInGroup[0];
+                          return (
+                            <li
+                              key={single.id}
+                              className="flex items-start p-3 bg-gray-50 rounded-md"
+                            >
+                              <span className="flex-shrink-0 w-6 h-6 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
+                                {single.order}
+                              </span>
+                              <ExerciseLink
+                                slug={single.exercise!.slug}
+                                name={group.typeName}
+                                className="text-blue-600 hover:text-blue-800 hover:underline"
+                                onPreview={setSelectedSlug}
+                                isActive={selectedSlug === single.exercise!.slug}
+                                previewLabel={previewLabel}
+                              />
+                            </li>
+                          );
+                        }
+
+                        // Multiple exercises or single with different name - group under type
+                        return (
+                          <li key={group.typeName} className="p-3 bg-gray-50 rounded-md">
+                            <div className="font-medium text-gray-700 mb-2">{group.typeName}</div>
+                            <ul className="ml-4 space-y-1">
+                              {exercisesInGroup.map(item => (
+                                <li key={item.id} className="flex items-start">
+                                  <span className="flex-shrink-0 w-5 h-5 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-xs font-medium mr-2">
+                                    {item.order}
+                                  </span>
+                                  <ExerciseLink
+                                    slug={item.exercise!.slug}
+                                    name={item.exercise!.name}
+                                    className="text-blue-600 hover:text-blue-800 hover:underline"
+                                    onPreview={setSelectedSlug}
+                                    isActive={selectedSlug === item.exercise!.slug}
+                                    previewLabel={previewLabel}
+                                  />
+                                </li>
+                              ))}
+                            </ul>
+                          </li>
+                        );
+                      });
+                    })()}
+                  </ul>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {selectedSlug && (
+          <aside className="mt-6 lg:mt-0 lg:w-1/2 lg:flex-shrink-0 lg:sticky lg:top-4 lg:self-start lg:max-h-[calc(100vh-2rem)] lg:overflow-y-auto">
+            <ExercisePreviewPanel
+              key={selectedSlug}
+              slug={selectedSlug}
+              onClose={() => setSelectedSlug(null)}
+            />
+          </aside>
         )}
       </div>
     </div>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -91,7 +91,10 @@
     "partOfSeason": "Part of season",
     "backToSeason": "Back to season {{name}}",
     "standaloneBanner": "This list shows standalone practice sessions only. Season-linked sessions live under their season.",
-    "standaloneBannerLink": "Open seasons"
+    "standaloneBannerLink": "Open seasons",
+    "previewExercise": "Preview exercise in side panel",
+    "closePreview": "Close preview",
+    "openInNewTab": "Open in new tab"
   },
   "seasons": {
     "title": "Seasons",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -91,7 +91,10 @@
     "partOfSeason": "Osa kautta",
     "backToSeason": "Takaisin kauteen {{name}}",
     "standaloneBanner": "Tämä lista näyttää vain yksittäiset harjoituskerrat. Kausiin sidotut harjoituskerrat löytyvät kausinäkymästä.",
-    "standaloneBannerLink": "Avaa kausinäkymä"
+    "standaloneBannerLink": "Avaa kausinäkymä",
+    "previewExercise": "Esikatsele harjoitus sivupaneelissa",
+    "closePreview": "Sulje esikatselu",
+    "openInNewTab": "Avaa uudessa välilehdessä"
   },
   "seasons": {
     "title": "Kaudet",


### PR DESCRIPTION
## Summary
- New panel icon next to each linked exercise on the practise session detail page; clicking it loads the exercise inline on the right side via `useFetcher` (no extra API route — re-uses the existing `/exercises/:slug` loader).
- Existing exercise text link still opens in a new tab. Items without a linked exercise (type-only entries) show no icon.
- Layout splits two columns at `lg` breakpoint and stacks vertically on smaller screens; right pane is `lg:sticky` so it stays visible while scrolling the session plan.
- Added `sessions.previewExercise`, `sessions.closePreview`, `sessions.openInNewTab` translations (en + fi).

## Test plan
- [ ] On a session with mixed entries (e.g. `/practise-sessions/testinen-2026-05-06`), confirm the panel icon appears only next to entries that link to an exercise.
- [ ] Click the icon — exercise loads in the right column with markdown, image (if any), duration, type, and YouTube link rendered.
- [ ] Click another exercise's icon — preview swaps; active icon highlights move with selection.
- [ ] Click the close (×) button — layout returns to single full-width column.
- [ ] Resize to <1024 px — preview stacks below the session plan.
- [ ] Click the exercise text link — opens in a new tab as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)