### PR TITLE
Fix back-link label on season coverage page

### DIFF
--- a/app/pages/SeasonCoveragePage.tsx
+++ b/app/pages/SeasonCoveragePage.tsx
@@ -24,7 +24,7 @@ export default function SeasonCoveragePage({ coverage }: SeasonCoveragePageProps
           to={`/seasons/${season.slug}`}
           className="text-blue-600 hover:text-blue-800 mb-4 inline-flex items-center"
         >
-          {t('seasons.backToSeasons')}
+          {t('sessions.backToSeason', { name: season.name })}
         </Link>
         <h1 className="mt-2 text-3xl font-bold">{t('coverage.title', { season: season.name })}</h1>
         <p className="mt-1 text-gray-600">{t('coverage.subtitle', { count: totalSessions })}</p>


### PR DESCRIPTION
## Summary
- The "back" link on `/seasons/:slug/coverage` pointed at the single season but read "Takaisin kausiin" (back to **seasons listing**) — the wrong label for the destination.
- Reuse the existing `sessions.backToSeason` translation with the season name interpolated, matching how `PractiseSessionDetail.tsx` renders the same kind of link ("Takaisin kauteen {{name}}").

## Test plan
- [ ] Visit `/seasons/<slug>/coverage` — back link now reads "Takaisin kauteen \<season name\>" / "Back to season \<season name\>".
- [ ] Click the link — still navigates to `/seasons/<slug>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)