### PR TITLE
Ignore Playwright MCP workspace and agent screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ node_modules
 
 # Claude Code config (personal, per-developer)
 .claude/
+
+# Browser test artifacts (Playwright MCP workspace + agent screenshots)
+/.playwright-mcp/
+/nav-*.png
+/preview-*.png


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/` (Playwright MCP server's workspace — snapshot YML, console logs) to `.gitignore`.
- Add `/nav-*.png` and `/preview-*.png` for the screenshots produced during agent verification runs.
- Patterns are root-anchored so they don't hide real images that live under `public/` or `app/`.

## Test plan
- [ ] After this lands, `git status` from a fresh clone with screenshots present should not list them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)