### PR TITLE
Fix recent-repeat hint rendering as raw translation key

### DIFF
--- a/app/pages/SeasonCoveragePage.tsx
+++ b/app/pages/SeasonCoveragePage.tsx
@@ -64,6 +64,7 @@ export default function SeasonCoveragePage({ coverage }: SeasonCoveragePageProps
                       {coverage.hints.recentRepeats.map((hint, idx) => (
                         <li key={`${hint.exerciseId}-${idx}`}>
                           {t('hints.repeatItem', {
+                            count: hint.gap,
                             name: hint.exerciseName,
                             gap: hint.gap,
                           })}


### PR DESCRIPTION
## Summary
- On `/seasons/:slug/coverage`, the "Saman harjoituksen toistoja" list rendered the literal string `hints.repeatItem` for every item.
- Root cause: `hints.repeatItem` is a pluralized i18next key (`_one` / `_other`) but the `t()` call passed only `name` and `gap`. Without `count`, i18next can't select a variant and falls back to the bare key, which doesn't exist.
- Fix: pass `count: hint.gap` alongside the existing interpolation values. `gap=1` → `_one` ("back-to-back"); `gap>1` → `_other` ("within N sessions").
- Verified in browser at `/seasons/testinen/coverage`: list now shows correct Finnish text for both gap=1 and gap=2 cases.

## Test plan
- [ ] Visit a coverage page where `recentRepeats` is non-empty — list items render full sentences (not the key).
- [ ] If a hint has `gap === 1`, message uses the "peräkkäisissä" / "back-to-back" wording.
- [ ] If a hint has `gap > 1`, message uses the "{{gap}} harjoituksen sisällä" / "within {{gap}} sessions" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)