### PR TITLE
Establish ADR + prompts conventions and seed initial docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,11 @@ General development
 - suggest improvements when applicable
 - you are allowed to question my instructions or ideas, if my ideas or actions may result in problems
 - notify me about possible security issues
+
+Architecture decision records (ADRs)
+
+- ADRs live in `docs/adr/`, numbered sequentially (`0001-...`, `0002-...`), using `docs/adr/template.md`
+- propose an ADR when a non-trivial decision is made: picking between real alternatives, adding or removing a feature, changing a cross-cutting pattern, or replacing a library
+- skip ADRs for typos, copy tweaks, dependency bumps, and other low-stakes changes
+- when an ADR applies, draft it and ask me to review before the PR merges; capture _why this over the alternatives_, not just _what_
+- never renumber or delete existing ADRs — supersede them by adding a new one and updating the old one's `Status:` to `Superseded by ADR-NNNN`

--- a/docs/Claude skills.md
+++ b/docs/Claude skills.md
@@ -1,0 +1,8 @@
+# Claude skills
+
+## Typescript skill
+
+Add this skill to this project only
+
+File: /Users/janimattiellonen/Documents/Development/Frisbeegolf/Harkkapankki/docs/Claude skills/typescript.md
+add "license: Complete terms in LICENSE.txt" to the beginning of the skill file

--- a/docs/Claude skills/LICENSE.txt
+++ b/docs/Claude skills/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/Claude skills/typescript.md
+++ b/docs/Claude skills/typescript.md
@@ -1,0 +1,63 @@
+license: Complete terms in LICENSE.txt
+name typescript
+description Expert in TypeScript development with best practices for type safety and clean code
+TypeScript
+
+You are an expert in TypeScript development with deep knowledge of type safety and modern JavaScript patterns.
+Core Principles
+Code Style & Structure
+
+    Write concise, technical TypeScript with accurate examples
+    Use functional and declarative programming patterns; avoid classes
+    Prefer iteration and modularization over code duplication
+    Use descriptive variable names with auxiliary verbs (e.g., isLoading, hasError)
+    Structure files: exported component, subcomponents, helpers, static content, types
+
+Naming Conventions
+
+    Use PascalCase for classes, types, and interfaces
+    Use camelCase for variables, functions, and methods
+    Use kebab-case for file and directory names
+    Use UPPERCASE for environment variables and constants
+    Prefix functions with verbs; use boolean prefixes like is, has, can
+
+TypeScript Usage
+
+    Use TypeScript for all code; prefer types over interfaces
+    Avoid any type; create precise type definitions
+    Use functional components with TypeScript interfaces
+    Avoid enums; use maps instead
+    Use readonly for immutable properties
+    Use as const for literal values
+
+Functions & Methods
+
+    Write short functions with single purpose (less than 20 lines)
+    Use arrow functions for simple operations (less than 3 lines)
+    Use named functions for complex logic
+    Implement early returns to avoid nested blocks
+    Use default parameters instead of null/undefined checks
+    Apply the RORO pattern: "Receive an Object, Return an Object"
+
+Data & Classes
+
+    Encapsulate data in composite types
+    Prefer immutability where possible
+    Follow SOLID principles
+    Prefer composition over inheritance
+    Keep classes under 200 lines with fewer than 10 public methods
+
+Error Handling
+
+    Use exceptions for unexpected errors
+    Implement proper error logging with context
+    Create custom error types for consistency
+    Use guard clauses for preconditions
+    Catch exceptions only to fix expected problems or add context
+
+Documentation
+
+    Use JSDoc for public classes and methods
+    Document all exports clearly
+    Provide usage examples when appropriate
+    Keep documentation concise and accurate

--- a/docs/adr/0001-side-panel-exercise-preview.md
+++ b/docs/adr/0001-side-panel-exercise-preview.md
@@ -1,0 +1,120 @@
+# 0001. Side-panel exercise preview on practise session detail
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+- **Deciders:** janimattiellonen
+- **Related:** PR #53, spec at `docs/prompts/practise session view improvements.md`, commit `ca8c363`
+
+## Context
+
+The practise session detail page (`/practise-sessions/:slug`) lists the exercises
+that belong to a session. Exercises that exist in the catalogue render as text
+links to `/exercises/:slug`. Until now the only way to review an exercise's
+content (description, image, embedded video, markdown body) was to open the link
+in a new tab.
+
+When a coach is planning or reviewing a session this means juggling tabs:
+read item → open exercise in tab → switch tab → read → switch back → next item.
+For a session with 8–12 linked exercises this is the dominant friction in the
+workflow. The spec called out that the main area "could be split into two
+columns (one with the existing content and the other with the selected
+exercise visible)" and asked for a small preview icon next to each linked
+exercise.
+
+Constraints:
+
+- Items _without_ a linked exercise (free-text section items) should not get
+  the affordance — there is nothing to preview.
+- The existing "open in new tab" behaviour is used and should not be taken
+  away.
+- The exercise body uses `@uiw/react-md-editor` for markdown rendering, which
+  is a heavy client-only dependency that the session detail page does not
+  otherwise load.
+- The session list view is dense on mobile; we cannot afford to break or
+  cramp that layout.
+
+## Decision
+
+We add a side-panel preview rendered inline on the same page, opened by
+clicking a small panel-icon button placed next to each linked exercise. The
+existing exercise text link is preserved and continues to open in a new tab.
+
+Concretely:
+
+- A new `ExercisePreviewPanel` component (`app/components/ExercisePreviewPanel.tsx`)
+  fetches the exercise via `useFetcher` against the existing
+  `/exercises/:slug` route — **no new API endpoint, no new loader, no
+  prop-drilled data.**
+- The markdown renderer (`@uiw/react-md-editor`) is **dynamically imported**
+  inside the panel, so it is only fetched when a user actually opens a
+  preview.
+- `PractiseSessionDetail` holds a single `selectedSlug` state. When set, the
+  page switches from a single column to a two-column flex layout at the `lg`
+  breakpoint and up; on smaller screens the panel stacks below the list.
+- The panel is `lg:sticky lg:top-4` with `max-h-[calc(100vh-2rem)] overflow-y-auto`
+  so it stays visible while the user scrolls the section list.
+- The preview button uses `aria-pressed` to convey active state and
+  `aria-label` (i18n key `sessions.previewExercise`) for screen readers.
+- Items with no linked exercise render no button at all — empty affordance is
+  worse than no affordance.
+
+## Alternatives considered
+
+- **Modal / dialog overlay.** Rejected: blocks the section list, breaks the
+  "I want to compare exercise contents against the surrounding session
+  structure" use case, and adds focus-trap complexity for no UX gain.
+- **Inline expand under each list item (accordion).** Rejected: pushes the
+  rest of the list down, loses the "scan the session, peek at exercises"
+  flow, and would need its own scroll handling for long markdown bodies.
+- **Navigate to the exercise detail page in the same tab.** Rejected: that's
+  effectively what we have today minus the new tab; the back-button round
+  trip is the friction the spec is trying to remove.
+- **Status quo (only "open in new tab").** Rejected: this is the explicit
+  problem the spec describes. New-tab behaviour is _retained_ as the
+  secondary affordance — the text link still opens in a tab — so users who
+  prefer that workflow lose nothing.
+- **Server-side: pre-load every exercise's content into the session loader.**
+  Rejected: pays full bandwidth and markdown-render cost up front for content
+  the user may never preview, and bloats the initial HTML payload.
+
+## Consequences
+
+### Positive
+
+- Removes tab-juggling for the dominant session-review flow.
+- No new backend surface — reuses the existing exercise route's loader.
+- Markdown bundle stays out of the critical path for users who don't open a
+  preview (lazy-loaded on first open).
+- Both affordances coexist: power users keep "middle-click → new tab", the
+  preview button covers the common case.
+
+### Negative / costs
+
+- `PractiseSessionDetail` grows a new `ExerciseLink` wrapper component and
+  conditional layout branching (`selectedSlug ? two-col : one-col`). The page
+  is now meaningfully more complex than it was.
+- Two ways to look at an exercise from this page is a duplicated affordance —
+  if we ever change navigation patterns we need to revisit both.
+- The panel re-fetches on each `slug` change. We do not cache previously
+  opened exercises; opening A → B → A re-fetches A. Acceptable given typical
+  session sizes (8–12 items) and the loader's small payload, but worth
+  noting if performance becomes an issue.
+- The two-column split only kicks in at `lg` (≥ 1024px). On tablets in
+  portrait the panel stacks below the list, which is functional but a step
+  down from the desktop experience.
+
+### Neutral / follow-ups
+
+- Consider keyboard navigation between previews (next / previous exercise)
+  if usage data shows people stepping through exercises sequentially.
+- If the markdown bundle continues to grow, consider a lighter renderer for
+  the preview-only path; we don't need the full editor surface here.
+- The "preview while editing a session" flow is _not_ covered — this ADR is
+  scoped to the read-only detail page.
+
+## References
+
+- Spec: `docs/prompts/practise session view improvements.md`
+- PR: [#53 feat/exercise-preview-panel](https://github.com/janimattiellonen/Harkkapankki/pull/53)
+- Commit: `ca8c363` — "Add side-panel exercise preview to practise session detail"
+- Files: `app/components/ExercisePreviewPanel.tsx`, `app/pages/PractiseSessionDetail.tsx`

--- a/docs/adr/0002-junnufriba-content-crawler.md
+++ b/docs/adr/0002-junnufriba-content-crawler.md
@@ -1,0 +1,126 @@
+# 0002. Junnufriba content acquisition via offline crawler
+
+- **Status:** Accepted
+- **Date:** 2025-10-07 (decision made), retroactively documented 2026-05-07
+- **Deciders:** janimattiellonen
+- **Related:** PR #16 (initial), PR #20 (multi-source + tests), spec at `docs/14 - Junnufriba crawler.txt`
+
+## Context
+
+Harkkapankki's exercise catalogue needs to be populated with high-quality
+content. The natural source is `junnufriba.fi` — the existing public site
+that hosts the youth coaching material this project is eventually intended
+to extend / hand over to (see `memory/project_purpose_and_vision.md`).
+
+That site publishes exercises as static HTML pages with a consistent shape:
+
+- Title in `<header class="entry-header">` → `<h1 class="entry-title">`
+- Body in `<div class="entry-content">` consisting of `<h3>`, `<p>`, ad-hoc
+  bullet lists made from `<p>` + `•`, embedded YouTube `<iframe>`s, and
+  images.
+
+There were ~30 exercises to import initially, with more arriving over time.
+Manual entry was on the table. So was building an in-app importer. The
+deciding question was: where does this code live, and how do we keep
+imported content reproducible?
+
+Constraints:
+
+- The project stores exercise body as **markdown**, not HTML, with a custom
+  YouTube tag (`@[youtube](url)`) the renderer already supports.
+- Images need to be persisted locally (`public/uploads/`) so we are not
+  hot-linking to junnufriba.fi.
+- Re-runs must be auditable — if we re-import a page we want to see what
+  changed, not silently overwrite.
+- The web app must not gain a public scraping surface (no reason to expose
+  HTTP fetch from a user-facing route).
+
+## Decision
+
+We built a **standalone Node/TypeScript crawler** under `scripts/crawler/`,
+separate from the React Router app, that:
+
+1. Accepts three input shapes — HTML file path, URL, or `.txt` list — and
+   delegates dispatch to `input-source.ts`.
+2. Parses HTML via `cheerio` in `parse-html.ts`, converting to markdown:
+   `<h3>` → `##`, ad-hoc `•` bullets → real markdown lists, YouTube iframes
+   → `@[youtube](url)` tags.
+3. Downloads images to a timestamped output directory and rewrites
+   references to `/public/uploads/...`.
+4. Writes a `content.json` (array of `{ header, body, exerciseTypeId }`)
+   plus a human-readable `content.md` to
+   `docs/junnufriba-crawler/parsed-data/<timestamp>/`.
+5. A **separate** script, `scripts/insert-content.ts`, reads that
+   `content.json` and inserts into the database. Parsing and insertion are
+   intentionally split so we can review the parse output before touching
+   the DB.
+
+## Alternatives considered
+
+- **Manual entry through the web app's exercise form.** Rejected: ~30
+  exercises with markdown bodies and embedded videos is hours of
+  copy/paste, with high risk of drift from the source. Also doesn't scale
+  to future re-imports.
+- **In-app admin importer (web UI that fetches a URL).** Rejected: adds
+  scraping capability to a public-facing app — attack surface, SSRF risk,
+  and UI for a workflow that runs maybe once a quarter.
+- **Hardcoded seed scripts with content inlined.** Rejected: divorces
+  imported content from its source URL; updating an exercise upstream means
+  hand-editing the seed, defeating the point.
+- **Headless browser (Puppeteer / Playwright).** Rejected: junnufriba.fi
+  serves static HTML — no JS execution required. Pulling in a headless
+  browser was disproportionate.
+- **Single combined parse-and-insert script.** Rejected: review-before-insert
+  is the whole reason the timestamped output directory exists. Splitting
+  into two scripts also makes it possible to re-run insertion against an
+  older parse without re-fetching.
+
+## Consequences
+
+### Positive
+
+- Imports are **reproducible and auditable** — every run leaves a
+  timestamped directory you can diff against the previous one. The folder
+  listing under `docs/junnufriba-crawler/parsed-data/` is now a de-facto
+  log of when content was pulled.
+- The web app stays free of crawling/HTTP-fetch code and the security
+  concerns that come with it.
+- Splitting parse from insert lets us hand-review the markdown output
+  before any DB writes.
+- The three input shapes (file / URL / list) cover one-off debugging,
+  single-page imports, and bulk runs without branching the script's public
+  surface.
+
+### Negative / costs
+
+- Two separate scripts means two `npx tsx` invocations to import a page —
+  small but real friction.
+- The parser is **coupled to junnufriba.fi's HTML structure**. If they
+  redesign, the crawler breaks; we own that maintenance. Selectors are
+  centralised in `parse-html.ts`, so a redesign is a one-file fix in
+  practice.
+- Images are downloaded to `public/uploads/` at insert time — the script
+  has filesystem write access to a public directory, which means a
+  malformed source URL could in principle write outside the intended path.
+  This is mitigated in `unique-filename.ts` but is worth knowing.
+- The crawler ships in the repo even though it's not part of the deployed
+  app. Acceptable cost given it's the only way to onboard content; the
+  alternative (separate repo) is heavier than the problem warrants.
+
+### Neutral / follow-ups
+
+- A later fix (PR #32, commit `2c1f415`) added a `featured-media` fallback
+  for image imports and a `public/uploads` sync step — see commit message
+  rather than amending this ADR.
+- If we ever take ingestion in a different direction (RSS feed, content
+  API, or upstream data export), this ADR should be superseded rather
+  than edited.
+
+## References
+
+- Spec: `docs/14 - Junnufriba crawler.txt`
+- Phase 1 PR: [#16 junnufriba-crawler](https://github.com/janimattiellonen/Harkkapankki/pull/16)
+- Phase 3+4 PR: [#20 multi-link-crawling](https://github.com/janimattiellonen/Harkkapankki/pull/20)
+- Image-import follow-up: PR #32 (commit `2c1f415`)
+- Code: `scripts/crawler/`, `scripts/insert-content.ts`
+- Sample run output: `docs/junnufriba-crawler/parsed-data/<timestamp>/`

--- a/docs/adr/0003-i18n-finnish-default-and-deterministic-uuids.md
+++ b/docs/adr/0003-i18n-finnish-default-and-deterministic-uuids.md
@@ -1,0 +1,143 @@
+# 0003. i18n with Finnish as default + deterministic exercise-type UUIDs
+
+- **Status:** Accepted
+- **Date:** 2025-10-09 (decisions made), retroactively documented 2026-05-07
+- **Deciders:** janimattiellonen
+- **Related:** PR #22 (locale env + deterministic UUIDs), PR #23 (full i18n), `docs/i18n-usage.md`
+
+## Context
+
+Harkkapankki's audience is Finnish-speaking junior frisbee golf coaches.
+The eventual handover target is `junnufriba.fi`, which is Finnish-only.
+However, the codebase had grown with hardcoded English copy throughout —
+labels, validation messages, navigation — and a `locale: 'en'` parameter
+threaded through every translation lookup.
+
+At the same time, the seed script was generating fresh `crypto.randomUUID()`
+values for each exercise type on every run. This meant:
+
+- Any environment that re-seeded got a different set of IDs.
+- Cross-environment data movement (dev → staging dump → local restore)
+  silently broke foreign-key references.
+- The crawler's `content.json` files (see ADR-0002) hard-code
+  `exerciseTypeId` per imported page, but those IDs only matched the most
+  recent seed run.
+
+Two related decisions had to be made together:
+
+1. How do we make Finnish the natural default while keeping English as a
+   live alternative for development and future reach?
+2. How do we make exercise-type IDs survive reseeds and environment
+   moves?
+
+## Decision
+
+### i18n
+
+- Adopt `remix-i18next` + `react-i18next` with two locales: `fi` and `en`.
+- Translations live in `public/locales/fi.json` and `public/locales/en.json`,
+  loaded **server-side and inlined into the initial HTML** (no client
+  HTTP fetch for translation bundles).
+- The default locale is read from `APP_LOCALE` env var, defaulting to
+  `'fi'` (`app/utils/locale.server.ts`):
+  ```ts
+  export function getDefaultLocale(): string {
+    return process.env.APP_LOCALE || 'fi';
+  }
+  ```
+- Every server-side service that previously took a hardcoded
+  `locale: 'en'` argument now calls `getDefaultLocale()`.
+- A `LanguageSwitcher` component lets users override at runtime.
+
+### Deterministic UUIDs
+
+- Exercise-type IDs are generated as **UUID v5** from the type's slug
+  (`prisma/seed.ts`):
+  ```ts
+  const namespace = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+  const hash = createHash('sha1').update(namespace + slug).digest('hex');
+  // formatted as a v5 UUID
+  ```
+- This makes IDs a pure function of the slug — same slug, same UUID, every
+  time, every machine.
+- The crawler's `content.json` files can therefore reference exercise
+  types by their canonical UUID without re-seed coupling.
+
+## Alternatives considered
+
+### For i18n
+
+- **Stay English-only and rely on browser translation.** Rejected:
+  unreliable for technical/sport-specific terminology, and incompatible
+  with the junnufriba.fi handover.
+- **Finnish-only, drop English entirely.** Rejected: English is useful
+  for development discussions, screenshots in this repo's PRs, and
+  potential future reach. The marginal cost of keeping `en.json` is small.
+- **Client-side translation loading via HTTP fetch.** Rejected: adds a
+  request to first paint, complicates SSR, and translation bundles for
+  two locales are a few KB — inlining them is cheaper than the round trip.
+- **`next-i18next` / a different library.** Rejected: this app uses
+  React Router 7 (post-Remix migration, ADR-0004), and `remix-i18next`
+  was the path of least resistance with native loader integration.
+  `next-i18next` was never on the table since this isn't Next.js.
+
+### For exercise-type IDs
+
+- **Auto-increment integers.** Rejected: forces sequence coordination
+  across environments; reseeds reset the sequence; no good for distributed
+  references in seed files or external systems like the crawler.
+- **Random UUID v4 with a stable lookup table** (`slug → uuid` map kept
+  in version control). Rejected: extra layer that solves the same problem
+  UUID v5 solves natively. Lookup tables drift from reality.
+- **Slug as the primary key directly.** Rejected: exercise-type slugs
+  may evolve (Finnish wording revisions); we want the slug to be the
+  human-readable handle and the UUID to be the immutable reference.
+
+## Consequences
+
+### Positive
+
+- All UI text is now translatable; new copy must go through translation
+  files, which keeps the Finnish surface complete by default. The
+  `docs/i18n-usage.md` guide codifies the conventions for future work.
+- Inlined translations mean **no extra HTTP requests** for i18n bundles
+  and SSR returns fully-translated HTML.
+- Reseeds, dev databases, and staging dumps all share the same
+  exercise-type UUIDs — `content.json` files in
+  `docs/junnufriba-crawler/parsed-data/` are durable references rather
+  than snapshot-bound IDs.
+- Switching `APP_LOCALE` between `fi` and `en` is a single env-var change
+  for ops or test environments.
+
+### Negative / costs
+
+- Every new component must remember to use `t('namespace.key')` instead
+  of inline strings — a discipline cost. There's no static check that
+  catches a bare-string regression today.
+- Two translation files must be kept in sync. Missing keys in one file
+  don't break the build; they fall back silently. This is on us to catch
+  in review.
+- The deterministic UUID scheme is **load-bearing on slug stability**.
+  Renaming an exercise-type slug changes its UUID, breaking every row
+  that references the old ID. This must be done as a deliberate migration,
+  not a casual edit.
+- `remix-i18next` is somewhat tied to the Remix/React Router ecosystem —
+  a future framework swap would mean redoing the SSR integration, not
+  just swapping libraries.
+
+### Neutral / follow-ups
+
+- A linter rule (or a custom ESLint plugin) that flags string literals
+  in JSX would close the discipline gap on missing translations. Not done
+  yet.
+- The `'6ba7b810-9dad-11d1-80b4-00c04fd430c8'` namespace is the standard
+  DNS namespace UUID. A project-specific namespace would be marginally
+  more correct semantically but offers no practical benefit; not worth
+  changing now.
+
+## References
+
+- Locale env + deterministic UUIDs: PR [#22 finnish-content-by-default](https://github.com/janimattiellonen/Harkkapankki/pull/22), commit `951ba7a`
+- Full translation infrastructure: PR [#23 add-translation-support](https://github.com/janimattiellonen/Harkkapankki/pull/23), commit `ca88651`
+- Usage guide: `docs/i18n-usage.md`
+- Code: `app/utils/locale.server.ts`, `app/i18n.server.ts`, `app/i18nextOptions.ts`, `app/components/LanguageSwitcher.tsx`, `public/locales/{fi,en}.json`, `prisma/seed.ts`

--- a/docs/adr/0004-remix-to-react-router-7-migration.md
+++ b/docs/adr/0004-remix-to-react-router-7-migration.md
@@ -1,0 +1,130 @@
+# 0004. Migrate from Remix v2 to React Router 7
+
+- **Status:** Accepted
+- **Date:** 2026-04-01 (decision made), retroactively documented 2026-05-07
+- **Deciders:** janimattiellonen
+- **Related:** PR #27 (migration), PR #28 (React 19 follow-up), spec at `docs/17 - upgrade to react router 7.md`
+
+## Context
+
+The project was built on Remix v2.16.6. In late 2024 / early 2025 the
+Remix team announced that Remix as a separate framework was being folded
+into React Router 7 — same loaders/actions/route conventions, same SSR
+model, but published under the `react-router` and `@react-router/*`
+packages. Remix v2 became, in effect, a frozen branch.
+
+The choice was: stay on a maintenance-mode framework, or migrate while
+the codebase was still small enough to do it cheaply.
+
+Constraints:
+
+- The app already had ~10 routes with loaders, actions, file uploads,
+  i18n integration (see ADR-0003), and form handling via
+  `react-hook-form`.
+- `remix-i18next` had a v6→v7 release that aligned with RR7 and kept the
+  class-based API the project already used.
+- The custom file-upload helper (`app/utils/upload.server.ts`) used
+  Remix's `unstable_*` upload handlers. RR7 removed those in favour of
+  standard Web APIs — so the upload code had to be rewritten regardless.
+
+## Decision
+
+Migrate the entire codebase to React Router 7 in a single PR (#27).
+Specifically:
+
+- Replace every `@remix-run/*` package with the `react-router` /
+  `@react-router/*` equivalents.
+- Swap the Remix Vite plugin for `reactRouter()` from
+  `@react-router/dev/vite`.
+- Add `react-router.config.ts` and `app/routes.ts` (RR7's explicit route
+  config — replaces filesystem-only convention).
+- Replace `json()` helper calls with plain returns; use `data()` only
+  where a non-200 status is needed.
+- Rewrite `app/utils/upload.server.ts` against standard `Request` /
+  `FormData` Web APIs instead of the removed Remix `unstable_*` upload
+  utilities.
+- Switch entry files: `RemixServer` → `ServerRouter`, `RemixBrowser` →
+  `HydratedRouter`.
+- Update `Date` typings: RR7's single-fetch preserves `Date` objects
+  through the loader boundary, so types like `scheduledAt: string` were
+  corrected to `Date`.
+- Bump `remix-i18next` from v6 → v7 (still supports the class-based API
+  used in `app/i18n.server.ts`).
+- Remove the now-stale "Architecture" and "Routes" sections from
+  `CLAUDE.md` — the conventions they described (`*.server.ts` files,
+  page-component split) survived the migration unchanged but were
+  documented in the wrong place.
+
+The migration was followed shortly by PR #28 (React 18 → 19), which
+RR7's peer dependencies allowed but didn't strictly require. That bump
+is intentionally **not** a separate ADR — RR7 was the forcing function
+and the React bump was a low-risk follow-on.
+
+## Alternatives considered
+
+- **Stay on Remix v2 indefinitely.** Rejected: Remix v2 receives only
+  critical fixes going forward; the ecosystem is moving to RR7. Every
+  month of delay grows the migration diff (more routes, more loaders,
+  more tests).
+- **Rewrite as a Next.js app.** Rejected: would discard the entire
+  loader/action model the codebase is built around. Migration cost would
+  be 10× the RR7 path, with no proportional benefit for an app this
+  size.
+- **Stay on Remix and adopt React Router for client-side routing only
+  (the v6 use-case).** Rejected: doesn't solve the maintenance question
+  — Remix is still the framework. Adds a second router for no gain.
+- **Migrate route by route on a long-lived branch.** Rejected: RR7 and
+  Remix v2 share enough surface that an incremental migration is
+  technically possible but practically painful — `package.json` can't
+  hold both `@remix-run/*` and `@react-router/*` cleanly. The codebase
+  was small enough (~10 routes, ~30 files touched) that a single PR was
+  faster.
+
+## Consequences
+
+### Positive
+
+- The framework is now on the supported, actively-developed track.
+- File-upload code is now standard Web API — portable, easier to test,
+  no `unstable_` prefix.
+- `react-router.config.ts` + `app/routes.ts` make the route map explicit
+  rather than purely filesystem-derived; new routes are registered in
+  one place.
+- Single-fetch preserves `Date` objects through loaders — removed several
+  defensive `new Date(stringValue)` calls at component boundaries.
+- The migration unlocked the React 19 upgrade (PR #28), which the React
+  Router 7 peer deps support natively.
+
+### Negative / costs
+
+- One large diff across 30+ files. Reviewable, but not a
+  cherry-pickable change. The PR is now the canonical reference for
+  "what changed in the migration".
+- `remix-i18next` is still the i18n adapter (v7). It tracks RR7 well
+  today, but a future RR7 major could put pressure on this dependency.
+  See ADR-0003's "neutral / follow-ups" note about framework coupling.
+- The `unstable_*` upload API rewrite is a behaviour-equivalent
+  reimplementation, not a verified-against-edge-cases one. Test coverage
+  on uploads is light; if regressions surface, expect them here.
+- All tooling integrations (typecheck script now runs
+  `react-router typegen && tsc`, dev/build/start scripts changed) had to
+  be updated. New contributors need to know `react-router dev`, not
+  `remix vite:dev`.
+
+### Neutral / follow-ups
+
+- React 18 → 19 followed in PR #28. The bump was unremarkable and is
+  not given its own ADR — flagged here for completeness.
+- The deleted CLAUDE.md sections ("Architecture", "Routes") described
+  conventions that still apply. They were removed because they assumed
+  Remix-specific framing; the underlying rules survive in the codebase.
+- If RR7 ships a breaking change in a future major, a follow-up ADR
+  should describe the upgrade path rather than amending this one.
+
+## References
+
+- Spec: `docs/17 - upgrade to react router 7.md`
+- Migration PR: [#27 remix-to-rr7](https://github.com/janimattiellonen/Harkkapankki/pull/27), commit `9ec3579`
+- React 19 follow-up: PR [#28 dependeny-upgrades](https://github.com/janimattiellonen/Harkkapankki/pull/28), commit `895dda7`
+- Upstream guide: https://reactrouter.com/upgrading/remix
+- Code: `react-router.config.ts`, `app/routes.ts`, `app/entry.{client,server}.tsx`, `app/utils/upload.server.ts`, `package.json`

--- a/docs/adr/0005-stylex-adoption.md
+++ b/docs/adr/0005-stylex-adoption.md
@@ -1,0 +1,154 @@
+# 0005. Adopt StyleX alongside Tailwind for component styling
+
+- **Status:** Accepted
+- **Date:** 2026-04-01 (first attempt, reverted same day) → 2026-05-03 (re-adoption merged), retroactively documented 2026-05-07
+- **Deciders:** janimattiellonen
+- **Related:** PR #30 (initial — merged then reverted), PR #31 (re-adoption with token system), spec at `docs/stylex.md`
+
+## Context
+
+The codebase started on Tailwind CSS for styling. As components grew, two
+problems emerged:
+
+1. **No design tokens.** Colour, spacing, and typography choices were
+   inline Tailwind classes with no semantic indirection — `bg-blue-600`
+   rather than `bg-buttonPrimary`. Refactoring the design palette would
+   require touching every component.
+2. **Implicit duplication.** Common patterns (button variants, card
+   layouts) were re-expressed as Tailwind class strings in each
+   component. There was no enforced shape for "primary button".
+
+StyleX (Meta's atomic CSS-in-JS library) was attractive because it
+combines:
+
+- Co-located styles (no separate file, no class-name churn).
+- Type-checked references — typos in token names fail the build.
+- Atomic CSS output — comparable bundle behaviour to Tailwind.
+- A `defineVars` system explicitly designed for semantic theme tokens.
+
+The plan was to introduce StyleX **alongside** Tailwind rather than
+replace it wholesale: convert hot spots (Button component, key cards)
+incrementally; let Tailwind continue to handle layout/utility classes
+during the transition.
+
+## The false start (PR #30)
+
+The first attempt — installing `@stylexjs/unplugin`, configuring the
+Vite plugin, converting `PractiseSessionSummary` and creating
+`Button.tsx` — was merged as PR #30, then **reverted within the same
+hour** (commits `d6e83cd` → `f3d2dec`, four seconds apart on the merge
+timeline).
+
+The reason isn't recorded in the revert commit message (just
+"Revert..."). The actual cause was discovered during the re-attempt:
+
+> **The Vite plugin was configured with `useCSSLayers: true`** (the
+> StyleX-recommended default). This wraps StyleX-generated CSS in a
+> `@layer` rule. Tailwind's base reset (also in a layer) then **won the
+> cascade** for the same properties, so Button's StyleX styles were
+> visually overridden by Tailwind's `button` reset. Buttons looked
+> unstyled despite the StyleX classes being present in the DOM.
+
+Two paths from there:
+
+- Strip out Tailwind's preflight/reset (giant, repo-wide).
+- Disable CSS layers in StyleX so its rules sit at normal specificity
+  and beat the reset.
+
+We chose the second.
+
+## Decision
+
+Re-adopt StyleX (PR #31) with two concrete changes vs. the first
+attempt:
+
+1. **`useCSSLayers: false`** in `vite.config.ts`. This is the load-bearing
+   line — without it, StyleX coexists badly with Tailwind's reset:
+   ```ts
+   stylexUnplugin.vite({
+     useCSSLayers: false,
+     // ...
+   })
+   ```
+2. **Centralised design tokens** in `app/styles/`:
+   - `tokens.stylex.ts` — semantic design vars (`textPrimary`,
+     `buttonPrimaryBackground`, etc.) defined via `defineVars`.
+   - `constants.stylex.ts` — raw spacing / font-size / radius scales.
+   Components consume tokens, never raw colour or pixel values.
+3. **A shared `Button` component** with `primary`, `secondary`, `danger`,
+   `ghost`, and `icon` variants. All 19 `<button>` elements in the app
+   were converted to use it.
+
+Tailwind stays in place for layout utilities (`flex`, `grid`, breakpoint
+prefixes, spacing utilities). StyleX is used for components and
+themable surfaces. Migration of remaining components is incremental.
+
+## Alternatives considered
+
+- **Stay on Tailwind only, adopt CSS variables for theming.** Rejected:
+  solves the token problem but doesn't address component-shape
+  duplication or give us a typed authoring experience.
+- **Adopt vanilla-extract** (similar Meta-adjacent ergonomics).
+  Rejected: smaller ecosystem in 2026, less aligned with React Server
+  Components / RR7 patterns than StyleX.
+- **Strip Tailwind entirely and go all-in on StyleX.** Rejected:
+  rewriting every layout and utility class would be a multi-week effort
+  with no incremental value. Hybrid is fine.
+- **Use `vite-plugin-stylex` instead of `@stylexjs/unplugin`** — the
+  alternative the spec doc compared against
+  (`docs/stylex.md` notes another RR7 setup using this). Rejected: the
+  unplugin variant is published by the StyleX team, supports the same
+  features, and the cause of our cascade issue (`useCSSLayers`) is a
+  StyleX-level config, not a plugin choice.
+- **Keep first-attempt config (`useCSSLayers: true`) and remove
+  Tailwind's base reset.** Rejected: Tailwind preflight does a lot of
+  work the codebase implicitly depends on (form-element resets, image
+  defaults). Disabling CSS layers is a one-line fix vs. an unknowable
+  blast radius.
+
+## Consequences
+
+### Positive
+
+- Theme tokens are now type-checked. Renaming a token surfaces every
+  consumer; missing tokens fail the build.
+- Button variants are defined in one place; changes to "what a primary
+  button looks like" are now a single-file edit.
+- StyleX and Tailwind coexist without specificity surprises.
+- The design tokens ladder (raw `constants.stylex.ts` →
+  semantic `tokens.stylex.ts` → component styles) is the canonical
+  pattern for future styling work.
+
+### Negative / costs
+
+- **`useCSSLayers: false` is a non-default setting tied to a specific
+  cascade interaction with Tailwind.** If Tailwind is ever removed or
+  its reset moved out of `@layer`, revisit this setting. This is the
+  single most easily-forgotten detail of the migration — it lives in
+  this ADR specifically because it would otherwise be lost.
+- Two styling systems means two mental models. Contributors need to
+  know when to reach for StyleX (component-shape, themable) vs.
+  Tailwind (layout, one-off utility).
+- Incremental migration means the codebase will be in a hybrid state
+  for some time. New components should default to StyleX for visual
+  styling; older components may still be Tailwind-only.
+- The original PR #30 lives in git history as merged-then-reverted —
+  GitHub still shows it as merged. Anyone bisecting around early April
+  needs to know the revert happened.
+
+### Neutral / follow-ups
+
+- Components written before PR #31 still mix Tailwind and inline styling.
+  Migrate opportunistically, not in a big-bang sweep.
+- If a Tailwind v4 upgrade changes how its layers work, this ADR's
+  cascade assumption needs re-validation.
+- A future ADR should be opened if we decide to drop Tailwind entirely
+  or to flip `useCSSLayers` back on.
+
+## References
+
+- Spec: `docs/stylex.md`
+- First attempt (merged then reverted): PR [#30 stylex](https://github.com/janimattiellonen/Harkkapankki/pull/30), commits `5ff0410` (add) → `f3d2dec` (revert)
+- Re-adoption: PR [#31 use-stylex](https://github.com/janimattiellonen/Harkkapankki/pull/31), commits `afd8530` (replace all buttons + `useCSSLayers: false` fix), `ef8f3b3` (token extraction)
+- Code: `vite.config.ts`, `app/styles/tokens.stylex.ts`, `app/styles/constants.stylex.ts`, `app/components/Button.tsx`
+- Plugin: `@stylexjs/unplugin`

--- a/docs/adr/0006-season-planning-feature-architecture.md
+++ b/docs/adr/0006-season-planning-feature-architecture.md
@@ -1,0 +1,199 @@
+# 0006. Season planning as a first-class entity with phased rollout
+
+- **Status:** Accepted
+- **Date:** 2026-04-04 (plan merged) → ongoing through Phase 3 (2026-05-06), retroactively documented 2026-05-07
+- **Deciders:** janimattiellonen
+- **Related:** PRs #33 (plan doc), #35 (schema), #37 (CRUD), #38 (add-sessions + auto-gen), #39 (standalone/season cleanup), #40 (coverage view), #41 (hints), spec at `docs/18 - season planning feature plan.md`
+
+> **Read the spec for full detail.** This ADR captures the architectural
+> rationale and rejected alternatives, not the schema or UX. The 225-line
+> plan doc is canonical for "what was built."
+
+## Context
+
+Harkkapankki's actual product goal — beyond "store and pick exercises"
+— is **planning a whole season** of weekly junior practice sessions
+that progress logically. Up to this point the app modelled a
+`PracticeSession` as a standalone, dateless object. Sessions had no
+parent grouping, no schedule, and no notion of belonging together.
+
+The author runs ~20–25 weekly sessions per season (April–October) on a
+fixed weekday/time, with occasional gaps. Building a full season's worth
+of sessions ad-hoc was the dominant manual workflow. The lack of
+structure meant:
+
+- No place to store season-level defaults (weekday, start time,
+  duration).
+- No batch creation — every session was created one-by-one.
+- No way to see "what have I covered across the season" or "did I
+  repeat the same drill three weeks running."
+- Long-term ambition (progression-aware planning) had nowhere to
+  attach.
+
+The spec doc (`docs/18 - season planning feature plan.md`) is the result
+of an extended design conversation. It settles 25 numbered decisions
+covering schema, UX, and auto-generation algorithm. This ADR captures
+the **architectural meta-decisions** behind that spec — the ones whose
+reasoning is non-obvious from the schema alone.
+
+## Decision
+
+### 1. Season is a first-class entity, not a tag
+
+Add a `Season` table with its own slug, name, description, date range,
+and default weekday/start-time/duration. `PracticeSession` gains a
+nullable `seasonId` FK and a nullable `scheduledAt` timestamp.
+
+### 2. Existing standalone sessions are preserved, not migrated
+
+All pre-existing rows get `seasonId = NULL` and `scheduledAt = NULL`.
+They remain reachable via `/practise-sessions` (which is filtered to
+standalone-only after PR D). No backfill, no compatibility shim.
+
+### 3. Season defaults are copy-on-create, not propagated
+
+When a session is added to a season, the season's `defaultDayOfWeek`,
+`defaultStartTime`, and `defaultDurationMin` are read **at creation
+time** to seed the session's fields. Editing the season later does
+**not** update existing sessions. This is the non-obvious one — coaches
+might expect changes to propagate. We chose not to: a session has a
+fixed real-world date, and retroactive edits to defaults would silently
+shift past sessions' metadata.
+
+### 4. Time is UTC `timestamptz`, rendered in Europe/Helsinki
+
+`scheduledAt` is stored as UTC. Helsinki wall-clock input is converted
+at write time via `date-fns-tz`. This is correct across DST transitions
+(twice per season). No fixed-offset arithmetic anywhere.
+
+### 5. Auto-generation is **pulled forward** from Phase 4 to Phase 1
+
+Originally Phase 4 was the only phase with auto-generation, and Phase 1
+would have shipped manual-only session creation. We pulled a **dumb
+baseline auto-gen** into Phase 1: one item per section, no-repeat
+within a rolling 3-session window applied within-batch only,
+type-only fallback when the exercise bank is sparse. Phase 4 will
+layer progression intelligence on top.
+
+Reason: without auto-gen, the "add sessions" form is just bulk manual
+entry — saves keystrokes but doesn't validate that the season concept
+adds value. Dumb auto-gen is enough to confirm the workflow before
+investing in progression algorithms.
+
+### 6. Phased delivery: A → prototype → B → C → D, then Phase 2/3/4
+
+- **PR A** (#35, `d116a4c`): schema migration only. No UI.
+- **Prototype** (commit `c30f1c9`): UI-only mock at
+  `/prototypes/season-form` to validate ergonomics before backend code
+  exists. Deleted before PR B.
+- **PR B** (#37, `de755c8`): season CRUD routes.
+- **PR C** (#38, `9abc18e`): `/seasons/$slug/add-sessions` + auto-gen.
+- **PR D** (#39, `aabcd76`): standalone-vs-season cleanup, nav, home
+  card.
+- **Phase 2** (#40, `f39eaf7`): coverage view (read-only "what you've
+  covered").
+- **Phase 3** (#41, `4c765aa`): hints (warnings for unbalanced or
+  repeating seasons).
+- **Phase 4** (commit `9331377` outlines scope): progression-aware
+  auto-generation — **not yet implemented.**
+
+### 7. No `weekNumber` column
+
+Calendar week and "session N of season" are both **derived** from
+`scheduledAt` at view time (`getISOWeek` and `row_number() over (...)`).
+Storing them would create two sources of truth that drift on date edits.
+
+### 8. `seasonId` mutable in schema, immutable in UI (Phase 1)
+
+The FK has `onDelete: SetNull` and is technically free to change. The
+edit form intentionally does **not** expose a season selector for
+Phase 1 — cross-season moves will land when there's actually more than
+one season.
+
+## Alternatives considered
+
+- **Model a season as a tag/category on `PracticeSession`.** Rejected:
+  defaults (weekday, start time, duration), date ranges, and slugs all
+  belong to the season, not the session. A tag has no place to store
+  this.
+- **Embed season as a JSON column on `PracticeSession`.** Rejected:
+  duplicates season metadata across every member session; updates
+  become rewrite-many; fundamentally the wrong shape.
+- **Store wall-clock local time directly (no UTC conversion).**
+  Rejected: DST transitions during the coaching season would silently
+  shift the displayed time of October sessions created in spring.
+- **Eagerly generate the entire season's worth of sessions on season
+  creation.** Rejected: too rigid. The "add N sessions at a time"
+  flow lets coaches react to the actual calendar, vacations, and
+  cancellations.
+- **Propagate season-default changes to existing sessions.** Rejected:
+  see decision #3 — sessions should snapshot defaults, not subscribe
+  to them.
+- **Store `weekNumber` and "session N" as columns.** Rejected: derive
+  from `scheduledAt` to avoid drift.
+- **Skip auto-generation in Phase 1.** Rejected: see decision #5 — a
+  dumb baseline validates the season concept before committing to
+  Phase 4's algorithm.
+- **Build season + Phase 4 progression in one big release.** Rejected:
+  too much risk for a feature whose core ergonomics are unvalidated.
+  The phased plan is partly explicit risk-management.
+
+## Consequences
+
+### Positive
+
+- Existing standalone-session data stays valid; no migration risk.
+- Schema is purely additive — one new table, three new nullable columns,
+  one composite index.
+- Phase 1's narrow scope was achievable in 4 PRs across ~2 weeks.
+  Phases 2 and 3 layered on without schema changes.
+- The plan doc itself is a useful artefact — it answered design
+  questions ahead of code, and PRs A–D could be reviewed against it.
+- Auto-gen is a pure function (`sessionAutoGenerator.server.ts`) given
+  a DB context, making it unit-testable.
+
+### Negative / costs
+
+- The codebase now has **two parallel session-creation paths** — manual
+  (`/practise-sessions/new`) and batch (`/seasons/$slug/add-sessions`)
+  — that share the same model but diverge on UX and defaults.
+- The `seasonId` immutability is a UI-only constraint. Anyone reading
+  the schema will see a mutable FK and may be surprised it's not
+  exposed in the form.
+- The exercise bank is sparse, so Phase 1's auto-gen falls back to
+  type-only items often. Acceptable but noted in the spec as a known
+  limitation.
+- Phase 4 (progression-aware auto-gen) is the actual product goal but
+  not yet built. Until it lands, season planning is "structured manual
+  entry with light variety enforcement," not "the system plans my
+  season for me."
+- DST correctness depends on always converting through the named zone.
+  A future contributor adding date arithmetic in raw UTC offsets could
+  silently break this — flagged here because it would be a subtle bug.
+
+### Neutral / follow-ups
+
+- A "regenerate programme" per-session button was deferred from
+  Phase 1. If users hit the bank-sparse fallback often, this becomes
+  a useful escape hatch.
+- The auto-gen's "rolling 3-session window" variety rule is
+  within-batch only. Cross-batch repeats are accepted; an upgrade to
+  cross-batch tracking is a code change with no schema impact.
+- Phase 4 should not amend this ADR — it should be its own ADR
+  describing the progression algorithm and how it interacts with the
+  Phase 1 baseline.
+- If multi-coach support ever lands (User table, auth), `Season`
+  ownership becomes a real concern. Out of scope today.
+
+## References
+
+- Spec doc: `docs/18 - season planning feature plan.md`
+- Plan PR: [#33 docs/season-planning-plan](https://github.com/janimattiellonen/Harkkapankki/pull/33)
+- PR A — schema: [#35](https://github.com/janimattiellonen/Harkkapankki/pull/35), commit `d116a4c`
+- PR B — CRUD: [#37](https://github.com/janimattiellonen/Harkkapankki/pull/37), commit `de755c8`
+- PR C — add-sessions + auto-gen: [#38](https://github.com/janimattiellonen/Harkkapankki/pull/38), commit `9abc18e`
+- PR D — cleanup + nav: [#39](https://github.com/janimattiellonen/Harkkapankki/pull/39), commit `aabcd76`
+- Phase 2 — coverage: [#40](https://github.com/janimattiellonen/Harkkapankki/pull/40), commit `f39eaf7`
+- Phase 3 — hints: [#41](https://github.com/janimattiellonen/Harkkapankki/pull/41), commit `4c765aa`
+- Phase 4 scope notes: commit `9331377`
+- Code: `prisma/schema.prisma` (Season model), `app/repositories/season.server.ts`, `app/services/sessionAutoGenerator.server.ts`, `app/utils/timezone.ts`

--- a/docs/adr/0007-one-query-per-file-repository-layout.md
+++ b/docs/adr/0007-one-query-per-file-repository-layout.md
@@ -1,0 +1,154 @@
+# 0007. One query per file with `query` prefix in `app/repositories/`
+
+- **Status:** Accepted
+- **Date:** 2026-05-05
+- **Deciders:** janimattiellonen
+- **Related:** PR #42, commit `44212fc`
+
+## Context
+
+By the time the season planning feature shipped (ADR-0006), the
+repository layer had grown to 5 monolithic files:
+
+```
+app/repositories/
+  exercise.server.ts          (~84 lines, multiple find/create/update)
+  practiceSession.server.ts   (~238 lines, ~10 query functions)
+  season.server.ts            (~146 lines)
+  exerciseType.server.ts
+  section.server.ts
+```
+
+Each file held a mixed bag of read and write functions for one
+domain entity. Three problems started showing up:
+
+1. **PR diffs were noisy.** Adding a new query meant editing a 200+
+   line file; reviewers had to scan the whole file to confirm nothing
+   else changed.
+2. **Grep returned too much context.** Searching for "where do we load a
+   practice session by slug" returned the whole repo file rather than
+   a single result.
+3. **Imports were ambiguous.** A page importing
+   `findPracticeSession` from `practiceSession.server.ts` could be
+   pulling any of half a dozen variants — by ID, by slug, with or
+   without sections, with or without coverage data. The function name
+   carried the meaning, but the import line gave no hint about which
+   query was being used until you looked inside.
+
+The team uses Claude Code heavily for changes; AI agents working with
+narrow context windows benefit from files-as-units-of-meaning more
+than humans do.
+
+## Decision
+
+Split the repository layer so that **each query function lives in its
+own file**, named `query<DescriptiveName>.server.ts`, exporting a
+single function with a matching `query`-prefixed name.
+
+5 monolithic files → 25+ single-purpose files. Examples:
+
+```
+app/repositories/queryExerciseBySlug.server.ts            // export queryExerciseBySlug
+app/repositories/queryCreateExercise.server.ts            // export queryCreateExercise
+app/repositories/queryUpdateExercise.server.ts            // export queryUpdateExercise
+app/repositories/queryDeleteExercise.server.ts            // export queryDeleteExercise
+app/repositories/queryPracticeSessionsBySlugPrefix.server.ts
+app/repositories/querySeasonBySlugWithCoverage.server.ts
+app/repositories/queryCreatePracticeSessionTx.server.ts   // transactional variant
+```
+
+Naming rules:
+
+- **Read queries** drop any `find*` verb and start directly with
+  `query` + entity + qualifier:
+  `findExerciseBySlug` → `queryExerciseBySlug`.
+- **Write queries** keep the operation verb after `query`:
+  `createExercise` → `queryCreateExercise`,
+  `updateSeason` → `queryUpdateSeason`,
+  `deleteExercise` → `queryDeleteExercise`.
+- **Transactional variants** suffix with `Tx`:
+  `queryCreatePracticeSessionTx`.
+- **Specialised reads** include the qualifier in the filename:
+  `queryPracticeSessionsBySlugPrefix`,
+  `querySeasonBySlugWithCoverage`,
+  `queryRootExerciseTypesWithChildren`.
+
+Files are flat under `app/repositories/` — no per-entity subdirectories.
+
+## Alternatives considered
+
+- **Keep 5 monolithic per-entity files.** Rejected: see context.
+  Workable, but every problem above gets worse as the app grows.
+- **Per-entity subdirectories** (`app/repositories/exercise/queryBySlug.ts`).
+  Rejected: extra path depth without payoff. The flat structure with
+  entity-prefixed filenames keeps `ls` and grep useful, and there's
+  no naming collision risk.
+- **Drop the `query` prefix; use entity + verb only**
+  (`exerciseBySlug.server.ts`). Rejected: the prefix makes it obvious
+  at a glance whether an import is a DB query vs. a service or
+  utility — useful both for humans scanning a file's imports and for
+  agent searches.
+- **Class-based repositories** (`ExerciseRepository.findBySlug()`).
+  Rejected: tree-shaking is worse, the codebase otherwise prefers
+  plain functions, and class methods don't compose with React Router 7
+  loaders any better than functions do.
+- **Inline queries directly in service files.** Rejected: services
+  ought to be testable in isolation from Prisma. Keeping the data
+  layer addressable behind named functions preserves that boundary
+  even when there's only one caller.
+
+## Consequences
+
+### Positive
+
+- **Diff scope is now exactly the change.** Adding a query is a new
+  file; modifying one touches only that file. Reviewers can read the
+  whole change in one screen.
+- **`grep "queryExerciseBySlug"` returns the definition and the
+  callers — full stop.** No hits on adjacent functions.
+- **Import lines self-document.** A page that imports
+  `querySeasonBySlugWithCoverage` is unambiguously loading the
+  coverage-augmented shape; no need to inspect the implementation.
+- **Agents work with smaller context windows.** Loading a 7-line query
+  file is cheaper than loading a 238-line repo file just to read one
+  function.
+- The convention is now codified — see decision rules above. New
+  queries go through the same shape automatically.
+
+### Negative / costs
+
+- **The `app/repositories/` directory has 25+ files.** Visual noise in
+  the directory listing. Mitigated by consistent prefixing —
+  `queryExercise*`, `queryPracticeSession*`, `querySeason*` cluster
+  alphabetically.
+- **Cross-cutting changes touch more files.** A schema-wide rename
+  ripples through every query file that references the renamed
+  field, vs. a single sweeping edit on one repo file before. In
+  practice this is `sed`-able and TypeScript surfaces missed updates.
+- **Slight import overhead.** Service files now import 5–8 query
+  functions instead of importing one repository module and reaching
+  into it.
+- **Adoption is total — no hybrid state.** PR #42 migrated all
+  repositories at once. New queries that don't follow the convention
+  will stand out in review.
+
+### Neutral / follow-ups
+
+- If the count crosses ~50 files, revisit per-entity subdirectories.
+  At 25 it is comfortably flat.
+- If a class of read queries grows (e.g., 10+ `querySeason*` variants
+  with shared inclusion logic), consider extracting shared
+  `include` / `select` shapes into a single helper file rather than
+  duplicating them across query files. Not done yet.
+- The convention was added to the project's coding standards
+  alongside this PR. Future ADRs that introduce new layers (e.g.,
+  a `commands/` directory for write-side orchestration) should
+  decide whether the same one-thing-per-file rule applies.
+
+## References
+
+- PR: [#42 refactor/repo-one-query-per-file](https://github.com/janimattiellonen/Harkkapankki/pull/42), commit `44212fc`
+- Verification: 84/84 tests still passing post-refactor; tsc, eslint,
+  prettier clean (recorded in commit message).
+- Code: `app/repositories/query*.server.ts`
+- Affected services: `app/services/{exercises,practiceSessions,seasons,exerciseTypes,sections}.server.ts`

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,43 @@
+# NNNN. Short title of the decision
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** name(s)
+- **Related:** PR #..., spec at `docs/prompts/...`, ADR-XXXX
+
+## Context
+
+What problem are we solving? What forces are at play (technical, UX, time, scope)?
+Describe the situation _before_ the decision. Include constraints that ruled options
+in or out. Be concrete — link the spec, the issue, the bug report.
+
+## Decision
+
+What did we decide to do? State it as a clear directive in present tense:
+"We will use X." Keep it short. Details live below.
+
+## Alternatives considered
+
+- **Option A — what it was.** Why rejected.
+- **Option B — what it was.** Why rejected.
+- **Status quo / do nothing.** Why insufficient.
+
+## Consequences
+
+### Positive
+
+- What gets better.
+
+### Negative / costs
+
+- What gets worse, what we now owe (tech debt, complexity, maintenance).
+
+### Neutral / follow-ups
+
+- Things to revisit, open questions, future ADRs that may supersede this one.
+
+## References
+
+- Spec: `docs/prompts/...`
+- PR: #...
+- Commit(s): `abcdef1`

--- a/docs/prompts/Documentation.md
+++ b/docs/prompts/Documentation.md
@@ -1,0 +1,125 @@
+# Documentation
+
+Write a non-technical project summary that describes in detail what features the project provides.
+
+A non-technical user that has no previous knowledge of the project, should be able to get a good picture of
+what the project does and provides.
+
+Store the written summary in `docs` directory.
+
+## Clarify project vision and reasons for existence
+
+Help me to refine and clarify why this project exists and what it aims to solve.
+
+Use /Users/janimattiellonen/Documents/Development/Frisbeegolf/Harkkapankki/docs/Project summary.md
+as a reference.
+
+## Answers to Claude's quetions
+
+### 1. The actual pain (problem statement)
+
+Between april and october, I run weekly training sessions for kids under 18 years.
+
+Each training session contains certain fixed parts:
+
+- introduction (we greet each others and change recent happenings)
+- warmup
+- putting practice
+- throwing practise
+- closing
+
+I need to come up with a new programme for each weeks' training session. I usually come up with
+the programme a day before, or even just hours before the session.
+
+I created this project as a tool that would allow me to create content for each training session
+more easily and with less pain.
+
+### 2. Origin & stake
+
+Currently I'm only experimenting a bit. A lot of the exercises are been scraped from https://junnufriba.fi
+I'm kind of "ere-creating" that website but with improved tools for creating the training
+sessions. I'm planning to contact the owner of https://junnufriba.fi/ and present my project to
+see, if they might be interested in it.
+
+### 3. Why not an existing tool
+
+I wanted to see, if I could create a better version of https://junnufriba.fi/ (see previous answer).
+
+### 5. Success criteria
+
+A definitive success criteria would be that https://junnufriba.fi/ would start using this project.
+
+A more personal success criteria in this current state would be that the project would really
+make it easy for me to create training sessions for several weeks, if not for the whole season,
+where the content of each training session would contain a varied types of practises etc so
+that no training session would feel like every other training session. What would be even greater,
+is that if the project would create training sessions for the whole season and create the contents
+in a way that the training sessions would follow a certain plan (progressively teach different
+techniques throughout the season in a logical order)
+
+## Next steps
+
+Currently, the project does not contain all the material found in junnnufriba.fi. This is fine
+for now, but it might become an issue when the project can be used to create a 10-week training
+programme: not enough material to create varied training sessions.
+
+This does not prevent us from implementing the season planning feature.
+
+Start working on a plan that assesses current features (code, database structure etc.) and how well
+they can be used for implementing the season planning feature.
+
+List possible issues and blockers. Suggest fixes for these. List changes required to the current
+database structure and code. A solid database structure is the foundation for the new feature.
+
+There is no concrete plan on what the season planning feature should contain.
+
+- a "season" might be 2 weeks or 20 weeks
+- each training session is normally held once a week, on a specific weekday and time and has a
+  specific length: wednesdays, 17.00 - 18.30 (1,5 hours) but the weekday, start and end times
+  might vary
+- there might be gaps between training session (summer vacation, sick days etc.)
+
+Answers to Claude:
+
+"Decision 1 — Is "season" a first-class entity?"
+
+Yes
+
+"Decision 2 — Schedule sessions to specific dates?"
+
+A. Scheduled -> I don't know in advance exactly, what weeks I may skip and when the final
+training session will be. Previous two seasons ended in mid october. I may add, delete or edit
+training sessions during the season. I might want to have a feature that allows me to create 3
+new training sessions in a row or use a calendar component for choosing which upcoming weeks
+will have a training session. We can deal with the implementation details later, as long as the
+database structure supports this.
+
+"Decision 3 — Variable session lengths?"
+
+For now, the 60/90 works fine.
+
+"Proposed schema (assuming yes / A / option-1)"
+
+Do we need `weekNumber`? can't we infer it from `scheduledAt`?
+
+"Issues / blockers / risks"
+
+"1. Doc 16 should land first"
+
+This is basically done.
+
+"Phased rollout"
+
+Phase 0 (prerequisite): Already resolved
+
+" 2. Existing standalone sessions — leave them be?"
+
+Can be left as they are. Just examples.
+
+"3. Auto-generation of session dates at season-creation time?"
+
+Correct
+
+"write this to docs/18 - season planning feature plan.md"
+
+Yes

--- a/docs/prompts/practise session view improvements.md
+++ b/docs/prompts/practise session view improvements.md
@@ -1,0 +1,12 @@
+# Practise session view improvements
+
+When I open a specific practise session (http://localhost:5177/practise-sessions/testinen-2026-05-06),
+I can see, what exercises has been added. Some of the exercises are links to the actual exercise.
+
+To review the actual exercise, I can open the link in a new window/tab. It would be better, if I
+also could see the contents of the practise on the same page, on the right side. The main area
+could be split into two columns (one with the existing content and the other with the selected
+exercise visible).
+
+Add a small icon beside the exercise link. If the link is clicked, show the exercise in question
+on the right side. If the exercise is not a link, don't show this icon.


### PR DESCRIPTION
## Summary
Adds the documentation framework we discussed so future readers can answer "why did we do X?" without spelunking commits.

- **CLAUDE.md**: rules for when to write an ADR (non-trivial decisions: alternatives considered, feature add/remove, cross-cutting pattern change, library swap) and how they're numbered. Skip for typos / copy tweaks / dependency bumps. Never renumber — supersede via a new ADR.
- **`docs/adr/template.md`**: standard ADR shape — Context / Decision / Alternatives considered / Consequences (positive, negative, follow-ups).
- **`docs/adr/0001`–`0007`**: existing decisions documented retroactively
  - 0001 — Side-panel exercise preview on practise session detail
  - 0002 — Junnufriba content acquisition via offline crawler
  - 0003 — i18n with Finnish as default + deterministic exercise-type UUIDs
  - 0004 — Migrate from Remix v2 to React Router 7
  - 0005 — Adopt StyleX alongside Tailwind for component styling
  - 0006 — Season planning as a first-class entity with phased rollout
  - 0007 — One query per file with `query` prefix in `app/repositories/`
- **`docs/prompts/`**: archive of the original specs / prompt files that drove features (`practise session view improvements.md`, `Documentation.md`).
- **`docs/Claude skills/`**: project-scoped TypeScript skill from Anthropic's official skills repo + the Apache 2.0 LICENSE that the upstream requires we keep alongside.

No code changes — docs only.

## Test plan
- [ ] Browse `docs/adr/` — each ADR renders cleanly on GitHub.
- [ ] Confirm the new CLAUDE.md guidance is consistent with existing sections.
- [ ] Confirm the LICENSE.txt is preserved alongside `typescript.md` (Apache 2.0 attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)