### PR TITLE
Add new feature workflow and feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Propose a new feature or non-trivial change
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem are we solving? Who is affected? Why now? -->
+
+## Proposed solution
+
+<!-- The agreed approach. Link any spec, prompt, or design notes. -->
+
+## Acceptance criteria
+
+<!-- Concrete, checkable conditions for "done". -->
+
+- [ ]
+- [ ]
+- [ ]
+
+## Out of scope
+
+<!-- Explicitly list what is NOT being built so scope stays bounded. -->
+
+## Notes
+
+<!-- ADR (if any), related issues/PRs, screenshots, references. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,15 @@ Architecture decision records (ADRs)
 - skip ADRs for typos, copy tweaks, dependency bumps, and other low-stakes changes
 - when an ADR applies, draft it and ask me to review before the PR merges; capture _why this over the alternatives_, not just _what_
 - never renumber or delete existing ADRs — supersede them by adding a new one and updating the old one's `Status:` to `Superseded by ADR-NNNN`
+
+New feature workflow
+
+When a feature or non-trivial change is requested, follow these steps in order. If unsure whether a step applies, ask before skipping.
+
+1. Triage. "Small" changes (typo or copy fix, isolated bug fix, dependency bump, behavior-preserving refactor) skip straight to implement + tests + lint. "Big" changes (user-facing feature, new domain concept, cross-cutting change, new dependency, architectural decision, or multi-module impact) follow steps 2–7.
+2. Refine the spec with the `grill-me` skill before writing code. For vague initial ideas, start with `agent-skills:idea-refine`. For larger work, follow up with `agent-skills:spec` and `agent-skills:plan`.
+3. Open a GitHub issue capturing the problem, agreed solution, and acceptance criteria — before implementation begins. The PR will reference it.
+4. Draft an ADR when a non-trivial decision is involved (see ADR rules above). Ask for review before merging the PR.
+5. Implement on a feature branch using the existing prefix convention (`feat/`, `fix/`, `chore/`, `refactor/`). Prefer `agent-skills:build` for incremental delivery on larger work.
+6. Add tests sized to the change: unit tests for new logic, plus integration or end-to-end tests when the change crosses modules, touches the database, or affects a user-visible flow. Use `agent-skills:test` for TDD on bug fixes.
+7. Run the pre-commit checks above, then open a PR (use `commit-push-pr`) linking the issue and any ADR.


### PR DESCRIPTION
## Summary
- Adds a 7-step "New feature workflow" section to `CLAUDE.md` so feature work follows a consistent triage → refine → issue → ADR → branch → test → PR sequence.
- Adds `.github/ISSUE_TEMPLATE/feature.md` matching the workflow (problem, proposed solution, acceptance criteria, out of scope, notes).
- References existing skills (`grill-me`, `agent-skills:idea-refine`, `agent-skills:spec`, `agent-skills:plan`, `agent-skills:build`, `agent-skills:test`, `commit-push-pr`) so the right tool is invoked at each step.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run format` clean (workflow files unchanged by prettier)
- [ ] Open a new issue on GitHub and confirm the feature template loads from `.github/ISSUE_TEMPLATE/feature.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)