### PR TITLE
Apply prettier formatting to ADR 0003 and 0005

### DIFF
--- a/docs/adr/0003-i18n-finnish-default-and-deterministic-uuids.md
+++ b/docs/adr/0003-i18n-finnish-default-and-deterministic-uuids.md
@@ -55,7 +55,9 @@ Two related decisions had to be made together:
   (`prisma/seed.ts`):
   ```ts
   const namespace = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-  const hash = createHash('sha1').update(namespace + slug).digest('hex');
+  const hash = createHash('sha1')
+    .update(namespace + slug)
+    .digest('hex');
   // formatted as a v5 UUID
   ```
 - This makes IDs a pure function of the slug — same slug, same UUID, every

--- a/docs/adr/0005-stylex-adoption.md
+++ b/docs/adr/0005-stylex-adoption.md
@@ -68,13 +68,13 @@ attempt:
    stylexUnplugin.vite({
      useCSSLayers: false,
      // ...
-   })
+   });
    ```
 2. **Centralised design tokens** in `app/styles/`:
    - `tokens.stylex.ts` — semantic design vars (`textPrimary`,
      `buttonPrimaryBackground`, etc.) defined via `defineVars`.
    - `constants.stylex.ts` — raw spacing / font-size / radius scales.
-   Components consume tokens, never raw colour or pixel values.
+     Components consume tokens, never raw colour or pixel values.
 3. **A shared `Button` component** with `primary`, `secondary`, `danger`,
    `ghost`, and `icon` variants. All 19 `<button>` elements in the app
    were converted to use it.


### PR DESCRIPTION
## Summary
- Pure prettier formatting drift in `docs/adr/0003-...md` and `docs/adr/0005-...md` surfaced when `npm run format` ran during PR #58.
- No semantic changes — only whitespace and a semicolon inside fenced code blocks.

## Test plan
- [x] `git diff` confirms only formatting changes
- [x] `npm run format` reports clean after this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)