### PR TITLE
Add retrospective to practice session

### DIFF
--- a/app/components/RetrospectiveSection.tsx
+++ b/app/components/RetrospectiveSection.tsx
@@ -42,13 +42,14 @@ export function RetrospectiveSection({ retrospective, actionData }: Retrospectiv
   const retroId = retrospective?.id ?? null;
   const retroUpdatedAt = retrospective?.updatedAt ?? null;
 
-  // After a successful save the action redirects back to this same URL,
-  // so the component stays mounted and isEditing would remain true. Reset
-  // it whenever the retrospective is created or updated so the read view
-  // takes over. Validation failures don't change retro identity, so the
-  // form correctly stays open with its errors.
+  // After a successful create/update/delete the action redirects back to
+  // this same URL, so the component stays mounted and any local UI flags
+  // would persist. Reset them whenever the retrospective's identity
+  // changes (created, updated, or deleted). Validation failures don't
+  // change identity, so the form correctly stays open with its errors.
   useEffect(() => {
     setIsEditing(false);
+    setShowDeleteDialog(false);
   }, [retroId, retroUpdatedAt]);
 
   const hasRetro = Boolean(retrospective);

--- a/app/components/RetrospectiveSection.tsx
+++ b/app/components/RetrospectiveSection.tsx
@@ -39,6 +39,18 @@ export function RetrospectiveSection({ retrospective, actionData }: Retrospectiv
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
+  const retroId = retrospective?.id ?? null;
+  const retroUpdatedAt = retrospective?.updatedAt ?? null;
+
+  // After a successful save the action redirects back to this same URL,
+  // so the component stays mounted and isEditing would remain true. Reset
+  // it whenever the retrospective is created or updated so the read view
+  // takes over. Validation failures don't change retro identity, so the
+  // form correctly stays open with its errors.
+  useEffect(() => {
+    setIsEditing(false);
+  }, [retroId, retroUpdatedAt]);
+
   const hasRetro = Boolean(retrospective);
   const isCreating = !hasRetro && isEditing;
   const isUpdating = hasRetro && isEditing;

--- a/app/components/RetrospectiveSection.tsx
+++ b/app/components/RetrospectiveSection.tsx
@@ -1,0 +1,398 @@
+import { useEffect, useState } from 'react';
+import { Form, useNavigation } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type MDEditor from '@uiw/react-md-editor';
+import { Button } from '~/components/Button';
+import {
+  retrospectiveFormSchema,
+  type RetrospectiveFormInput,
+} from '~/schemas/retrospective';
+
+type SerializedRetrospective = {
+  id: string;
+  participantCount: number;
+  summary: string;
+  wentWell: string | null;
+  improvements: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+};
+
+type RetrospectiveActionData = {
+  intent: string | null;
+  fieldErrors: Record<string, string>;
+  formError?: string;
+};
+
+type RetrospectiveSectionProps = {
+  retrospective: SerializedRetrospective | null | undefined;
+  actionData?: RetrospectiveActionData;
+};
+
+const isRetrospectiveIntent = (intent: string | null | undefined) =>
+  intent === 'retrospective-create' ||
+  intent === 'retrospective-update' ||
+  intent === 'retrospective-delete';
+
+export function RetrospectiveSection({ retrospective, actionData }: RetrospectiveSectionProps) {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+  const [isEditing, setIsEditing] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const hasRetro = Boolean(retrospective);
+  const isCreating = !hasRetro && isEditing;
+  const isUpdating = hasRetro && isEditing;
+
+  const isSubmitting =
+    navigation.state === 'submitting' &&
+    isRetrospectiveIntent(navigation.formData?.get('intent') as string | null);
+  const isDeleting =
+    navigation.state === 'submitting' &&
+    navigation.formData?.get('intent') === 'retrospective-delete';
+
+  const showFieldErrors =
+    actionData?.intent === 'retrospective-create' || actionData?.intent === 'retrospective-update';
+  const showFormError = isRetrospectiveIntent(actionData?.intent ?? null);
+
+  return (
+    <section className="mt-10 border-t pt-8">
+      <h2 className="text-xl font-semibold mb-4">{t('retrospective.title')}</h2>
+
+      {showFormError && actionData?.formError ? (
+        <div className="mb-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+          {actionData.formError}
+        </div>
+      ) : null}
+
+      {!hasRetro && !isCreating ? (
+        <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center">
+          <p className="text-gray-600 mb-4">{t('retrospective.emptyHint')}</p>
+          <Button type="button" onClick={() => setIsEditing(true)}>
+            {t('retrospective.add')}
+          </Button>
+        </div>
+      ) : null}
+
+      {hasRetro && !isUpdating ? (
+        <ReadView
+          retrospective={retrospective!}
+          onEdit={() => setIsEditing(true)}
+          onDelete={() => setShowDeleteDialog(true)}
+          isDeleting={isDeleting}
+        />
+      ) : null}
+
+      {isEditing ? (
+        <RetrospectiveForm
+          retrospective={retrospective ?? null}
+          fieldErrors={showFieldErrors ? (actionData?.fieldErrors ?? {}) : {}}
+          isSubmitting={isSubmitting}
+          onCancel={() => setIsEditing(false)}
+        />
+      ) : null}
+
+      {showDeleteDialog && retrospective ? (
+        <DeleteDialog
+          retrospectiveId={retrospective.id}
+          isDeleting={isDeleting}
+          onCancel={() => setShowDeleteDialog(false)}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+type ReadViewProps = {
+  retrospective: SerializedRetrospective;
+  onEdit: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+};
+
+function ReadView({ retrospective, onEdit, onDelete, isDeleting }: ReadViewProps) {
+  const { t } = useTranslation();
+  const [MarkdownComponent, setMarkdownComponent] = useState<typeof MDEditor.Markdown | null>(null);
+
+  useEffect(() => {
+    import('@uiw/react-md-editor').then(mod => {
+      setMarkdownComponent(() => mod.default.Markdown);
+    });
+  }, []);
+
+  const renderMarkdown = (text: string) =>
+    MarkdownComponent ? (
+      <MarkdownComponent source={text} />
+    ) : (
+      <div className="whitespace-pre-line">{text}</div>
+    );
+
+  return (
+    <div className="space-y-6 rounded-lg border border-gray-200 bg-white p-6">
+      <div className="flex flex-wrap items-baseline justify-between gap-4">
+        <div>
+          <p className="text-sm text-gray-500">{t('retrospective.participantCount')}</p>
+          <p className="text-3xl font-semibold">{retrospective.participantCount}</p>
+        </div>
+        <div className="flex gap-2">
+          <Button type="button" variant="secondary" onClick={onEdit} disabled={isDeleting}>
+            {t('common.edit')}
+          </Button>
+          <Button type="button" variant="danger" onClick={onDelete} disabled={isDeleting}>
+            {t('common.delete')}
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 mb-2">{t('retrospective.summary')}</h3>
+        <div className="[&_ul]:list-disc [&_ul]:ml-6 [&_ol]:list-decimal [&_ol]:ml-6">
+          {renderMarkdown(retrospective.summary)}
+        </div>
+      </div>
+
+      {retrospective.wentWell ? (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">
+            {t('retrospective.wentWell')}
+          </h3>
+          <div className="[&_ul]:list-disc [&_ul]:ml-6 [&_ol]:list-decimal [&_ol]:ml-6">
+            {renderMarkdown(retrospective.wentWell)}
+          </div>
+        </div>
+      ) : null}
+
+      {retrospective.improvements ? (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">
+            {t('retrospective.improvements')}
+          </h3>
+          <div className="[&_ul]:list-disc [&_ul]:ml-6 [&_ol]:list-decimal [&_ol]:ml-6">
+            {renderMarkdown(retrospective.improvements)}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type RetrospectiveFormProps = {
+  retrospective: SerializedRetrospective | null;
+  fieldErrors: Record<string, string>;
+  isSubmitting: boolean;
+  onCancel: () => void;
+};
+
+function RetrospectiveForm({
+  retrospective,
+  fieldErrors,
+  isSubmitting,
+  onCancel,
+}: RetrospectiveFormProps) {
+  const { t } = useTranslation();
+  const [MDEditorComponent, setMDEditorComponent] = useState<typeof MDEditor | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    import('@uiw/react-md-editor').then(mod => {
+      setMDEditorComponent(() => mod.default);
+    });
+  }, []);
+
+  const {
+    register,
+    control,
+    formState: { errors },
+    setError,
+  } = useForm<RetrospectiveFormInput>({
+    resolver: zodResolver(retrospectiveFormSchema),
+    values: {
+      participantCount: retrospective ? String(retrospective.participantCount) : '',
+      summary: retrospective?.summary ?? '',
+      wentWell: retrospective?.wentWell ?? '',
+      improvements: retrospective?.improvements ?? '',
+    },
+  });
+
+  useEffect(() => {
+    Object.entries(fieldErrors).forEach(([field, message]) => {
+      setError(field as keyof RetrospectiveFormInput, { type: 'server', message });
+    });
+  }, [fieldErrors, setError]);
+
+  const intent = retrospective ? 'retrospective-update' : 'retrospective-create';
+  const submitLabel = retrospective ? t('common.save') : t('retrospective.add');
+
+  return (
+    <Form method="post" className="space-y-4 rounded-lg border border-gray-200 bg-white p-6">
+      <input type="hidden" name="intent" value={intent} />
+      {retrospective ? (
+        <input type="hidden" name="retrospectiveId" value={retrospective.id} />
+      ) : null}
+
+      <div>
+        <label
+          htmlFor="participantCount"
+          className="block text-sm font-medium text-gray-700"
+        >
+          {t('retrospective.participantCount')}
+        </label>
+        <input
+          type="number"
+          id="participantCount"
+          min={0}
+          max={100}
+          step={1}
+          {...register('participantCount')}
+          className="mt-1 block w-32 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+        />
+        {errors.participantCount ? (
+          <p className="mt-1 text-sm text-red-600">{errors.participantCount.message}</p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="summary" className="block text-sm font-medium text-gray-700 mb-2">
+          {t('retrospective.summary')}
+        </label>
+        <Controller
+          name="summary"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <div key={mounted ? 'editor-summary' : 'textarea-summary'}>
+              {mounted && MDEditorComponent ? (
+                <MDEditorComponent
+                  value={value ?? ''}
+                  onChange={val => onChange(val ?? '')}
+                  preview="edit"
+                  height={200}
+                />
+              ) : (
+                <textarea
+                  id="summary"
+                  rows={4}
+                  value={value ?? ''}
+                  onChange={e => onChange(e.target.value)}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                />
+              )}
+            </div>
+          )}
+        />
+        {errors.summary ? (
+          <p className="mt-1 text-sm text-red-600">{errors.summary.message}</p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="wentWell" className="block text-sm font-medium text-gray-700 mb-2">
+          {t('retrospective.wentWell')}
+        </label>
+        <Controller
+          name="wentWell"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <div key={mounted ? 'editor-wentWell' : 'textarea-wentWell'}>
+              {mounted && MDEditorComponent ? (
+                <MDEditorComponent
+                  value={value ?? ''}
+                  onChange={val => onChange(val ?? '')}
+                  preview="edit"
+                  height={200}
+                />
+              ) : (
+                <textarea
+                  id="wentWell"
+                  rows={4}
+                  value={value ?? ''}
+                  onChange={e => onChange(e.target.value)}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                />
+              )}
+            </div>
+          )}
+        />
+        {errors.wentWell ? (
+          <p className="mt-1 text-sm text-red-600">{errors.wentWell.message}</p>
+        ) : null}
+      </div>
+
+      <div>
+        <label htmlFor="improvements" className="block text-sm font-medium text-gray-700 mb-2">
+          {t('retrospective.improvements')}
+        </label>
+        <Controller
+          name="improvements"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <div key={mounted ? 'editor-improvements' : 'textarea-improvements'}>
+              {mounted && MDEditorComponent ? (
+                <MDEditorComponent
+                  value={value ?? ''}
+                  onChange={val => onChange(val ?? '')}
+                  preview="edit"
+                  height={200}
+                />
+              ) : (
+                <textarea
+                  id="improvements"
+                  rows={4}
+                  value={value ?? ''}
+                  onChange={e => onChange(e.target.value)}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                />
+              )}
+            </div>
+          )}
+        />
+        {errors.improvements ? (
+          <p className="mt-1 text-sm text-red-600">{errors.improvements.message}</p>
+        ) : null}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onCancel} disabled={isSubmitting}>
+          {t('common.cancel')}
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {submitLabel}
+        </Button>
+      </div>
+    </Form>
+  );
+}
+
+type DeleteDialogProps = {
+  retrospectiveId: string;
+  isDeleting: boolean;
+  onCancel: () => void;
+};
+
+function DeleteDialog({ retrospectiveId, isDeleting, onCancel }: DeleteDialogProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">
+          {t('retrospective.deleteTitle')}
+        </h3>
+        <p className="text-gray-600 mb-6">{t('retrospective.deleteConfirm')}</p>
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={isDeleting}>
+            {t('common.cancel')}
+          </Button>
+          <Form method="post">
+            <input type="hidden" name="intent" value="retrospective-delete" />
+            <input type="hidden" name="retrospectiveId" value={retrospectiveId} />
+            <Button type="submit" variant="danger" disabled={isDeleting}>
+              {t('common.delete')}
+            </Button>
+          </Form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/RetrospectiveSection.tsx
+++ b/app/components/RetrospectiveSection.tsx
@@ -5,10 +5,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type MDEditor from '@uiw/react-md-editor';
 import { Button } from '~/components/Button';
-import {
-  retrospectiveFormSchema,
-  type RetrospectiveFormInput,
-} from '~/schemas/retrospective';
+import { retrospectiveFormSchema, type RetrospectiveFormInput } from '~/schemas/retrospective';
 
 type SerializedRetrospective = {
   id: string;
@@ -234,10 +231,7 @@ function RetrospectiveForm({
       ) : null}
 
       <div>
-        <label
-          htmlFor="participantCount"
-          className="block text-sm font-medium text-gray-700"
-        >
+        <label htmlFor="participantCount" className="block text-sm font-medium text-gray-700">
           {t('retrospective.participantCount')}
         </label>
         <input

--- a/app/components/RetrospectiveSection.tsx
+++ b/app/components/RetrospectiveSection.tsx
@@ -256,24 +256,27 @@ function RetrospectiveForm({
           name="summary"
           control={control}
           render={({ field: { onChange, value } }) => (
-            <div key={mounted ? 'editor-summary' : 'textarea-summary'}>
-              {mounted && MDEditorComponent ? (
-                <MDEditorComponent
-                  value={value ?? ''}
-                  onChange={val => onChange(val ?? '')}
-                  preview="edit"
-                  height={200}
-                />
-              ) : (
-                <textarea
-                  id="summary"
-                  rows={4}
-                  value={value ?? ''}
-                  onChange={e => onChange(e.target.value)}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                />
-              )}
-            </div>
+            <>
+              <div key={mounted ? 'editor-summary' : 'textarea-summary'}>
+                {mounted && MDEditorComponent ? (
+                  <MDEditorComponent
+                    value={value ?? ''}
+                    onChange={val => onChange(val ?? '')}
+                    preview="edit"
+                    height={200}
+                  />
+                ) : (
+                  <textarea
+                    id="summary"
+                    rows={4}
+                    value={value ?? ''}
+                    onChange={e => onChange(e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                  />
+                )}
+              </div>
+              <input type="hidden" name="summary" value={value ?? ''} />
+            </>
           )}
         />
         {errors.summary ? (
@@ -289,24 +292,27 @@ function RetrospectiveForm({
           name="wentWell"
           control={control}
           render={({ field: { onChange, value } }) => (
-            <div key={mounted ? 'editor-wentWell' : 'textarea-wentWell'}>
-              {mounted && MDEditorComponent ? (
-                <MDEditorComponent
-                  value={value ?? ''}
-                  onChange={val => onChange(val ?? '')}
-                  preview="edit"
-                  height={200}
-                />
-              ) : (
-                <textarea
-                  id="wentWell"
-                  rows={4}
-                  value={value ?? ''}
-                  onChange={e => onChange(e.target.value)}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                />
-              )}
-            </div>
+            <>
+              <div key={mounted ? 'editor-wentWell' : 'textarea-wentWell'}>
+                {mounted && MDEditorComponent ? (
+                  <MDEditorComponent
+                    value={value ?? ''}
+                    onChange={val => onChange(val ?? '')}
+                    preview="edit"
+                    height={200}
+                  />
+                ) : (
+                  <textarea
+                    id="wentWell"
+                    rows={4}
+                    value={value ?? ''}
+                    onChange={e => onChange(e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                  />
+                )}
+              </div>
+              <input type="hidden" name="wentWell" value={value ?? ''} />
+            </>
           )}
         />
         {errors.wentWell ? (
@@ -322,24 +328,27 @@ function RetrospectiveForm({
           name="improvements"
           control={control}
           render={({ field: { onChange, value } }) => (
-            <div key={mounted ? 'editor-improvements' : 'textarea-improvements'}>
-              {mounted && MDEditorComponent ? (
-                <MDEditorComponent
-                  value={value ?? ''}
-                  onChange={val => onChange(val ?? '')}
-                  preview="edit"
-                  height={200}
-                />
-              ) : (
-                <textarea
-                  id="improvements"
-                  rows={4}
-                  value={value ?? ''}
-                  onChange={e => onChange(e.target.value)}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                />
-              )}
-            </div>
+            <>
+              <div key={mounted ? 'editor-improvements' : 'textarea-improvements'}>
+                {mounted && MDEditorComponent ? (
+                  <MDEditorComponent
+                    value={value ?? ''}
+                    onChange={val => onChange(val ?? '')}
+                    preview="edit"
+                    height={200}
+                  />
+                ) : (
+                  <textarea
+                    id="improvements"
+                    rows={4}
+                    value={value ?? ''}
+                    onChange={e => onChange(e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                  />
+                )}
+              </div>
+              <input type="hidden" name="improvements" value={value ?? ''} />
+            </>
           )}
         />
         {errors.improvements ? (

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import ExercisePreviewPanel from '~/components/ExercisePreviewPanel';
+import { RetrospectiveSection } from '~/components/RetrospectiveSection';
 
 type SectionItem = {
   id: string;
@@ -26,6 +27,16 @@ type SectionItem = {
   } | null;
 };
 
+type Retrospective = {
+  id: string;
+  participantCount: number;
+  summary: string;
+  wentWell: string | null;
+  improvements: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+};
+
 type PracticeSessionData = {
   id: string;
   name: string | null;
@@ -36,10 +47,18 @@ type PracticeSessionData = {
   createdAt: Date;
   updatedAt: Date;
   sectionItems: SectionItem[];
+  retrospective?: Retrospective | null;
+};
+
+type RetrospectiveActionData = {
+  intent: string | null;
+  fieldErrors: Record<string, string>;
+  formError?: string;
 };
 
 type PractiseSessionDetailProps = {
   session: PracticeSessionData;
+  actionData?: RetrospectiveActionData;
 };
 
 type ExerciseLinkProps = {
@@ -92,7 +111,10 @@ function ExerciseLink({
   );
 }
 
-export default function PractiseSessionDetail({ session }: PractiseSessionDetailProps) {
+export default function PractiseSessionDetail({
+  session,
+  actionData,
+}: PractiseSessionDetailProps) {
   const { t } = useTranslation();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
 
@@ -317,6 +339,11 @@ export default function PractiseSessionDetail({ session }: PractiseSessionDetail
           </aside>
         )}
       </div>
+
+      <RetrospectiveSection
+        retrospective={session.retrospective ?? null}
+        actionData={actionData}
+      />
     </div>
   );
 }

--- a/app/pages/PractiseSessionDetail.tsx
+++ b/app/pages/PractiseSessionDetail.tsx
@@ -111,10 +111,7 @@ function ExerciseLink({
   );
 }
 
-export default function PractiseSessionDetail({
-  session,
-  actionData,
-}: PractiseSessionDetailProps) {
+export default function PractiseSessionDetail({ session, actionData }: PractiseSessionDetailProps) {
   const { t } = useTranslation();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
 
@@ -340,10 +337,7 @@ export default function PractiseSessionDetail({
         )}
       </div>
 
-      <RetrospectiveSection
-        retrospective={session.retrospective ?? null}
-        actionData={actionData}
-      />
+      <RetrospectiveSection retrospective={session.retrospective ?? null} actionData={actionData} />
     </div>
   );
 }

--- a/app/pages/PractiseSessionsList.tsx
+++ b/app/pages/PractiseSessionsList.tsx
@@ -11,6 +11,7 @@ type PracticeSession = {
   _count: {
     sectionItems: number;
   };
+  retrospective: { id: string } | null;
 };
 
 type PractiseSessionsListProps = {
@@ -78,8 +79,30 @@ export default function PractiseSessionsList({ sessions }: PractiseSessionsListP
             >
               <div className="flex justify-between items-start">
                 <div className="flex-1 min-w-0">
-                  <h2 className="text-xl font-semibold text-blue-600">
-                    {session.name || t('sessions.untitledSession')}
+                  <h2 className="text-xl font-semibold text-blue-600 flex items-center gap-2">
+                    <span>{session.name || t('sessions.untitledSession')}</span>
+                    {session.retrospective ? (
+                      <span
+                        title={t('retrospective.hasRetro')}
+                        aria-label={t('retrospective.hasRetro')}
+                        className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-emerald-100 text-emerald-700"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 12h6m-6 4h6M7 8h10M5 4h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z"
+                          />
+                        </svg>
+                      </span>
+                    ) : null}
                   </h2>
                   <p className="text-xs text-gray-500 mt-1">{formatDate(session.createdAt)}</p>
                   {session.description && (

--- a/app/repositories/queryCreateRetrospective.server.ts
+++ b/app/repositories/queryCreateRetrospective.server.ts
@@ -1,0 +1,21 @@
+import { db } from '~/utils/db.server';
+
+export type CreateRetrospectiveData = {
+  practiceSessionId: string;
+  participantCount: number;
+  summary: string;
+  wentWell?: string | null;
+  improvements?: string | null;
+};
+
+export async function queryCreateRetrospective(data: CreateRetrospectiveData) {
+  return db.practiceSessionRetrospective.create({
+    data: {
+      practiceSessionId: data.practiceSessionId,
+      participantCount: data.participantCount,
+      summary: data.summary,
+      wentWell: data.wentWell ?? null,
+      improvements: data.improvements ?? null,
+    },
+  });
+}

--- a/app/repositories/queryDeleteRetrospective.server.ts
+++ b/app/repositories/queryDeleteRetrospective.server.ts
@@ -1,0 +1,7 @@
+import { db } from '~/utils/db.server';
+
+export async function queryDeleteRetrospective(id: string) {
+  return db.practiceSessionRetrospective.delete({
+    where: { id },
+  });
+}

--- a/app/repositories/queryPracticeSessionBySlug.server.ts
+++ b/app/repositories/queryPracticeSessionBySlug.server.ts
@@ -29,6 +29,7 @@ export async function queryPracticeSessionBySlug(slug: string, language: string)
           },
         },
       },
+      retrospective: true,
     },
   });
 }

--- a/app/repositories/queryPracticeSessions.server.ts
+++ b/app/repositories/queryPracticeSessions.server.ts
@@ -16,6 +16,9 @@ export async function queryPracticeSessions(options: QueryPracticeSessionsOption
           sectionItems: true,
         },
       },
+      retrospective: {
+        select: { id: true },
+      },
     },
   });
 }

--- a/app/repositories/queryRetrospectiveBySessionId.server.ts
+++ b/app/repositories/queryRetrospectiveBySessionId.server.ts
@@ -1,0 +1,7 @@
+import { db } from '~/utils/db.server';
+
+export async function queryRetrospectiveBySessionId(practiceSessionId: string) {
+  return db.practiceSessionRetrospective.findUnique({
+    where: { practiceSessionId },
+  });
+}

--- a/app/repositories/queryUpdateRetrospective.server.ts
+++ b/app/repositories/queryUpdateRetrospective.server.ts
@@ -1,0 +1,20 @@
+import { db } from '~/utils/db.server';
+
+export type UpdateRetrospectiveData = {
+  participantCount: number;
+  summary: string;
+  wentWell?: string | null;
+  improvements?: string | null;
+};
+
+export async function queryUpdateRetrospective(id: string, data: UpdateRetrospectiveData) {
+  return db.practiceSessionRetrospective.update({
+    where: { id },
+    data: {
+      participantCount: data.participantCount,
+      summary: data.summary,
+      wentWell: data.wentWell ?? null,
+      improvements: data.improvements ?? null,
+    },
+  });
+}

--- a/app/routes/practise-sessions.$slug.tsx
+++ b/app/routes/practise-sessions.$slug.tsx
@@ -102,10 +102,7 @@ export async function action({ params, request }: ActionFunctionArgs) {
     }
   }
 
-  return data(
-    { intent: null, fieldErrors: {}, formError: 'Unknown intent' },
-    { status: 400 }
-  );
+  return data({ intent: null, fieldErrors: {}, formError: 'Unknown intent' }, { status: 400 });
 }
 
 export default function PracticeSessionDetailRoute() {

--- a/app/routes/practise-sessions.$slug.tsx
+++ b/app/routes/practise-sessions.$slug.tsx
@@ -1,7 +1,19 @@
-import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { useLoaderData } from 'react-router';
+import {
+  data,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from 'react-router';
+import { useActionData, useLoaderData } from 'react-router';
 import PractiseSessionDetail from '~/pages/PractiseSessionDetail';
+import { retrospectiveSchema } from '~/schemas/retrospective';
 import { fetchPracticeSessionBySlug } from '~/services/practiceSessions.server';
+import {
+  createRetrospective,
+  deleteRetrospective,
+  updateRetrospective,
+} from '~/services/retrospectives.server';
 import { getDefaultLocale } from '~/utils/locale.server';
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
@@ -21,7 +33,83 @@ export async function loader({ params }: LoaderFunctionArgs) {
   return { session };
 }
 
+export async function action({ params, request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const intent = formData.get('intent');
+
+  const session = await fetchPracticeSessionBySlug(params.slug!, getDefaultLocale());
+  if (!session) {
+    throw new Response('Practice session not found', { status: 404 });
+  }
+
+  if (intent === 'retrospective-delete') {
+    const retrospectiveId = formData.get('retrospectiveId');
+    if (typeof retrospectiveId !== 'string' || retrospectiveId === '') {
+      return data(
+        { intent, fieldErrors: {}, formError: 'Missing retrospective id' },
+        { status: 400 }
+      );
+    }
+    try {
+      await deleteRetrospective(retrospectiveId);
+      return redirect(`/practise-sessions/${session.slug}`);
+    } catch {
+      return data(
+        { intent, fieldErrors: {}, formError: 'Failed to delete retrospective' },
+        { status: 500 }
+      );
+    }
+  }
+
+  if (intent === 'retrospective-create' || intent === 'retrospective-update') {
+    const parsed = retrospectiveSchema.safeParse({
+      participantCount: formData.get('participantCount'),
+      summary: formData.get('summary'),
+      wentWell: formData.get('wentWell'),
+      improvements: formData.get('improvements'),
+    });
+
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const key = issue.path[0];
+        if (typeof key === 'string' && !fieldErrors[key]) {
+          fieldErrors[key] = issue.message;
+        }
+      }
+      return data({ intent, fieldErrors, formError: undefined }, { status: 400 });
+    }
+
+    try {
+      if (intent === 'retrospective-create') {
+        await createRetrospective(session.id, parsed.data);
+      } else {
+        const retrospectiveId = formData.get('retrospectiveId');
+        if (typeof retrospectiveId !== 'string' || retrospectiveId === '') {
+          return data(
+            { intent, fieldErrors: {}, formError: 'Missing retrospective id' },
+            { status: 400 }
+          );
+        }
+        await updateRetrospective(retrospectiveId, parsed.data);
+      }
+      return redirect(`/practise-sessions/${session.slug}`);
+    } catch {
+      return data(
+        { intent, fieldErrors: {}, formError: 'Failed to save retrospective' },
+        { status: 500 }
+      );
+    }
+  }
+
+  return data(
+    { intent: null, fieldErrors: {}, formError: 'Unknown intent' },
+    { status: 400 }
+  );
+}
+
 export default function PracticeSessionDetailRoute() {
   const { session } = useLoaderData<typeof loader>();
-  return <PractiseSessionDetail session={session} />;
+  const actionData = useActionData<typeof action>();
+  return <PractiseSessionDetail session={session} actionData={actionData} />;
 }

--- a/app/schemas/retrospective.ts
+++ b/app/schemas/retrospective.ts
@@ -21,12 +21,9 @@ const optionalText = z
 
 // Used by client-side react-hook-form. All fields are strings; no transforms.
 export const retrospectiveFormSchema = z.object({
-  participantCount: z
-    .string()
-    .min(1, 'Participant count is required')
-    .refine(isParticipantCount, {
-      message: 'Participant count must be a whole number between 0 and 100',
-    }),
+  participantCount: z.string().min(1, 'Participant count is required').refine(isParticipantCount, {
+    message: 'Participant count must be a whole number between 0 and 100',
+  }),
 
   summary: z
     .string()

--- a/app/schemas/retrospective.ts
+++ b/app/schemas/retrospective.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+const optionalText = z
+  .string()
+  .optional()
+  .transform(val => {
+    if (!val) {
+      return undefined;
+    }
+    const trimmed = val.trim();
+    return trimmed === '' ? undefined : trimmed;
+  });
+
+export const retrospectiveSchema = z.object({
+  participantCount: z
+    .string()
+    .min(1, 'Participant count is required')
+    .refine(
+      val => {
+        const num = Number(val);
+        return Number.isInteger(num) && num >= 0 && num <= 100;
+      },
+      { message: 'Participant count must be a whole number between 0 and 100' }
+    )
+    .transform(val => Number(val)),
+
+  summary: z
+    .string()
+    .min(1, 'Summary is required')
+    .transform(val => val.trim())
+    .refine(val => val.length > 0, { message: 'Summary is required' }),
+
+  wentWell: optionalText,
+
+  improvements: optionalText,
+});
+
+export type RetrospectiveFormInput = z.input<typeof retrospectiveSchema>;
+export type RetrospectiveFormData = z.infer<typeof retrospectiveSchema>;

--- a/app/schemas/retrospective.ts
+++ b/app/schemas/retrospective.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod';
 
+const PARTICIPANT_COUNT_MIN = 0;
+const PARTICIPANT_COUNT_MAX = 100;
+
+const isParticipantCount = (val: string) => {
+  const num = Number(val);
+  return Number.isInteger(num) && num >= PARTICIPANT_COUNT_MIN && num <= PARTICIPANT_COUNT_MAX;
+};
+
 const optionalText = z
   .string()
   .optional()
@@ -11,17 +19,33 @@ const optionalText = z
     return trimmed === '' ? undefined : trimmed;
   });
 
+// Used by client-side react-hook-form. All fields are strings; no transforms.
+export const retrospectiveFormSchema = z.object({
+  participantCount: z
+    .string()
+    .min(1, 'Participant count is required')
+    .refine(isParticipantCount, {
+      message: 'Participant count must be a whole number between 0 and 100',
+    }),
+
+  summary: z
+    .string()
+    .min(1, 'Summary is required')
+    .refine(val => val.trim().length > 0, { message: 'Summary is required' }),
+
+  wentWell: z.string().optional(),
+
+  improvements: z.string().optional(),
+});
+
+// Used server-side: parses + transforms to typed values.
 export const retrospectiveSchema = z.object({
   participantCount: z
     .string()
     .min(1, 'Participant count is required')
-    .refine(
-      val => {
-        const num = Number(val);
-        return Number.isInteger(num) && num >= 0 && num <= 100;
-      },
-      { message: 'Participant count must be a whole number between 0 and 100' }
-    )
+    .refine(isParticipantCount, {
+      message: 'Participant count must be a whole number between 0 and 100',
+    })
     .transform(val => Number(val)),
 
   summary: z
@@ -35,5 +59,5 @@ export const retrospectiveSchema = z.object({
   improvements: optionalText,
 });
 
-export type RetrospectiveFormInput = z.input<typeof retrospectiveSchema>;
+export type RetrospectiveFormInput = z.infer<typeof retrospectiveFormSchema>;
 export type RetrospectiveFormData = z.infer<typeof retrospectiveSchema>;

--- a/app/services/retrospectives.server.ts
+++ b/app/services/retrospectives.server.ts
@@ -1,0 +1,38 @@
+import { queryCreateRetrospective } from '~/repositories/queryCreateRetrospective.server';
+import { queryDeleteRetrospective } from '~/repositories/queryDeleteRetrospective.server';
+import { queryRetrospectiveBySessionId } from '~/repositories/queryRetrospectiveBySessionId.server';
+import { queryUpdateRetrospective } from '~/repositories/queryUpdateRetrospective.server';
+
+export type RetrospectiveInput = {
+  participantCount: number;
+  summary: string;
+  wentWell?: string;
+  improvements?: string;
+};
+
+export async function fetchRetrospectiveBySessionId(practiceSessionId: string) {
+  return queryRetrospectiveBySessionId(practiceSessionId);
+}
+
+export async function createRetrospective(practiceSessionId: string, input: RetrospectiveInput) {
+  return queryCreateRetrospective({
+    practiceSessionId,
+    participantCount: input.participantCount,
+    summary: input.summary,
+    wentWell: input.wentWell ?? null,
+    improvements: input.improvements ?? null,
+  });
+}
+
+export async function updateRetrospective(id: string, input: RetrospectiveInput) {
+  return queryUpdateRetrospective(id, {
+    participantCount: input.participantCount,
+    summary: input.summary,
+    wentWell: input.wentWell ?? null,
+    improvements: input.improvements ?? null,
+  });
+}
+
+export async function deleteRetrospective(id: string) {
+  return queryDeleteRetrospective(id);
+}

--- a/docs/adr/0008-practice-session-retrospective.md
+++ b/docs/adr/0008-practice-session-retrospective.md
@@ -7,9 +7,9 @@
 
 ## Context
 
-Harkkapankki today models the *plan* for a practice session
+Harkkapankki today models the _plan_ for a practice session
 (`PracticeSession` + `PracticeSessionSectionItem`) but has no place
-for the *outcome*: how many participants showed up, what actually got
+for the _outcome_: how many participants showed up, what actually got
 run, what worked, what to improve. The author writes the weekly
 programme the day-of and currently has nowhere in the app to record
 post-session reflections that would feed back into next week's plan
@@ -34,7 +34,7 @@ Constraints in play:
 
 ### 1. Retrospective is an inline subresource, not a first-class entity
 
-The retrospective is always reached *through* its parent practice
+The retrospective is always reached _through_ its parent practice
 session. It has **no slug**, **no dedicated routes**, and **no
 listing page**. Add / view / edit / delete all happen inline on
 `/practise-sessions/$slug`. The session detail page is the only
@@ -124,8 +124,8 @@ opening each session.
 
 ### Positive
 
-- Schema is purely additive — one new table, one FK with `@unique`
-  + `onDelete: Cascade`.
+- Schema is purely additive — one new table, one FK that is both
+  `@unique` and `onDelete: Cascade`.
 - Lifecycle is fully described by the parent session — delete the
   session, the retro goes with it.
 - Inline UX matches the read-while-editing reality of writing

--- a/docs/adr/0008-practice-session-retrospective.md
+++ b/docs/adr/0008-practice-session-retrospective.md
@@ -1,0 +1,168 @@
+# 0008. Practice session retrospective as a private, inline subresource
+
+- **Status:** Proposed
+- **Date:** 2026-05-07
+- **Deciders:** janimattiellonen
+- **Related:** Issue [#60](https://github.com/janimattiellonen/Harkkapankki/issues/60), spec at `docs/prompts/Exercise retrospective.md`
+
+## Context
+
+Harkkapankki today models the *plan* for a practice session
+(`PracticeSession` + `PracticeSessionSectionItem`) but has no place
+for the *outcome*: how many participants showed up, what actually got
+run, what worked, what to improve. The author writes the weekly
+programme the day-of and currently has nowhere in the app to record
+post-session reflections that would feed back into next week's plan
+and into the long-term season-planning vision (ADR-0006).
+
+Constraints in play:
+
+- **Single-user, public-no-auth dev state.** No login, no permissions
+  layer (per project vision; multi-user is out of scope until the
+  junnufriba handover).
+- **Privacy intent.** The retrospective content is for the coach's
+  eyes only. If the app is ever made public, retros must remain
+  hidden behind authentication and never appear on any public route.
+- **CRUD convention.** Every existing first-class resource (Exercise,
+  PracticeSession, Season) has its own slug, dedicated routes
+  (`new` / `$slug` / `$id_.edit`), and repository functions.
+- **Markdown tooling already exists** in the project
+  (`react-md-editor`, `react-markdown-preview`) and is used for
+  `Exercise.content`.
+
+## Decision
+
+### 1. Retrospective is an inline subresource, not a first-class entity
+
+The retrospective is always reached *through* its parent practice
+session. It has **no slug**, **no dedicated routes**, and **no
+listing page**. Add / view / edit / delete all happen inline on
+`/practise-sessions/$slug`. The session detail page is the only
+surface.
+
+### 2. Cardinality 0..1 enforced at the database
+
+A new table `practice_session_retrospectives` with
+`practice_session_id` as a `@unique` foreign key — at most one
+retrospective per session, enforced by Postgres rather than by
+application code.
+
+### 3. Cascade delete from PracticeSession
+
+`onDelete: Cascade` — deleting a session removes its retrospective.
+Retros have no meaning detached from their session.
+
+### 4. Privacy as a release-blocking constraint, not technical gating
+
+Today the retrospective renders inline on the session page with no
+auth gate (because the app has no auth). Before any public deployment:
+
+- Retros must be hidden behind authentication, OR
+- The retrospective fields must be omitted from server responses for
+  unauthenticated requests.
+
+This is a **release-blocking checklist item** for
+`agent-skills:shipping-and-launch`. We do **not** add an env-flag
+belt-and-braces today — the eventual fix is real auth, and a flag
+would be dead code by then.
+
+### 5. Field shape
+
+Four fields:
+
+- `participantCount: Int` — required, 0–100 (Zod-validated).
+- `summary: String @db.Text` — required, markdown, "what we did."
+- `wentWell: String? @db.Text` — optional, markdown.
+- `improvements: String? @db.Text` — optional, markdown.
+
+Plus `id`, `practiceSessionId`, `createdAt`, `updatedAt`.
+
+### 6. Markdown reuse, not a new editor
+
+Reuse the existing `react-md-editor`-based component used for
+`Exercise.content`. No new editor, no new dependency.
+
+### 7. Indicator on the practice sessions list
+
+The practice sessions index page shows a small icon/badge on rows
+that have a retrospective, so coverage is glanceable without
+opening each session.
+
+## Alternatives considered
+
+- **Retrospective as a first-class resource with its own slug and
+  routes.** Rejected — needless ceremony for a tightly coupled
+  subresource. The retro has no meaningful identity outside its
+  parent session, no need to link to it, and no listing surface.
+- **Embed retro fields directly on `PracticeSession`.** Rejected —
+  mixes plan with outcome on the same row; adds four nullable
+  columns to a frequently-loaded table; muddies the lifecycle
+  (creating/deleting retros becomes UPDATEs on the session).
+- **Multiple retrospectives per session (0..N).** Rejected — no
+  identified use case. If history-of-edits ever matters, drop the
+  `@unique` and add an order/version column. Today, edit-in-place
+  is sufficient.
+- **Soft delete (`deletedAt` column).** Rejected — personal coaching
+  notes, no audit/compliance need. Hard delete + confirmation dialog
+  is the right level of safety.
+- **Env flag (`SHOW_RETROSPECTIVES`) for pre-auth privacy.** Rejected
+  — adds noise for a deployment scenario that's months/years out and
+  will be replaced by real auth. Capturing privacy as a release-blocker
+  in this ADR is the durable mechanism.
+- **Standalone "all retrospectives" listing page.** Rejected for
+  MVP — out of scope. Easy to add later if cross-session browsing
+  becomes a need.
+- **Pre-fill `summary` from the planned program.** Rejected for MVP
+  — out of scope; the planned program is on the same page already.
+  Could be a one-click "import program summary" later.
+- **Separate route for create/edit (matching the per-resource
+  pattern).** Rejected — the inline flow matches how a retro is
+  actually used (re-read while editing). Documented here so future
+  contributors know the deviation is deliberate.
+
+## Consequences
+
+### Positive
+
+- Schema is purely additive — one new table, one FK with `@unique`
+  + `onDelete: Cascade`.
+- Lifecycle is fully described by the parent session — delete the
+  session, the retro goes with it.
+- Inline UX matches the read-while-editing reality of writing
+  reflections.
+- Reuses existing markdown editor — no new dependency.
+- The retro is discoverable via the indicator on the sessions list
+  without adding a new top-level navigation item.
+
+### Negative / costs
+
+- Departure from the per-resource-route CRUD convention. A future
+  contributor scanning `app/routes/` will notice retros have no
+  routes; this ADR is the answer to "why?"
+- Privacy enforcement is **process-bound**, not technically enforced.
+  An accidental public deployment without first adding auth would
+  expose retros. Mitigated by: (a) ADR explicitness, (b) a
+  release-blocking checklist item, (c) the project being explicitly
+  pre-handover with no current public deployment.
+- The `@unique` constraint locks 0..1 cardinality — if 0..N is ever
+  needed, schema migration required (drop unique, add order/version).
+
+### Neutral / follow-ups
+
+- If cross-session reflection becomes valuable (e.g., season-level
+  rollups), revisit with a follow-up ADR rather than amending this one.
+- If the season-planning roadmap (Phase 4 of ADR-0006) wants to
+  consume retrospective signals as inputs to progression decisions,
+  that's a separate design.
+- If a "regenerate / duplicate retro" flow ever shows up as
+  desirable, treat it as a new decision, not an extension of this ADR.
+
+## References
+
+- Spec prompt: `docs/prompts/Exercise retrospective.md`
+- Issue: [#60](https://github.com/janimattiellonen/Harkkapankki/issues/60)
+- Related: ADR-0003 (i18n), ADR-0006 (season planning context),
+  ADR-0007 (one query per file)
+- Code (post-implementation): `prisma/schema.prisma`,
+  `app/repositories/queryRetrospective*.server.ts`,
+  `app/pages/PractiseSessionDetail.tsx`

--- a/docs/prompts/Exercise retrospective.md
+++ b/docs/prompts/Exercise retrospective.md
@@ -1,18 +1,19 @@
 # Exercise retrospective
 
 After a practise session I might want to write a small retrospective:
+
 - how many participants
 - what we did
 - what went good, what might need improvements
 
 Thoughts on implementation:
+
 - a new database table is needed
 - internal memo. The content of the retrospective is not public.
 - I should be able to add a new retrospective when viewing a practise session
   - the created retrospective should be editable and removable
 
-
 ## Additional notes
 
-In some cases I may start the process by creating the github issue myself. In such case, a similar 
+In some cases I may start the process by creating the github issue myself. In such case, a similar
 process needs to be followed. The only difference is that the issue has already been created.

--- a/docs/prompts/Exercise retrospective.md
+++ b/docs/prompts/Exercise retrospective.md
@@ -1,0 +1,18 @@
+# Exercise retrospective
+
+After a practise session I might want to write a small retrospective:
+- how many participants
+- what we did
+- what went good, what might need improvements
+
+Thoughts on implementation:
+- a new database table is needed
+- internal memo. The content of the retrospective is not public.
+- I should be able to add a new retrospective when viewing a practise session
+  - the created retrospective should be editable and removable
+
+
+## Additional notes
+
+In some cases I may start the process by creating the github issue myself. In such case, a similar 
+process needs to be followed. The only difference is that the issue has already been created.

--- a/prisma/migrations/20260507124725_add_practice_session_retrospective/migration.sql
+++ b/prisma/migrations/20260507124725_add_practice_session_retrospective/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "practice_session_retrospectives" (
+    "id" TEXT NOT NULL,
+    "practice_session_id" TEXT NOT NULL,
+    "participant_count" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "went_well" TEXT,
+    "improvements" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "practice_session_retrospectives_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "practice_session_retrospectives_practice_session_id_key" ON "practice_session_retrospectives"("practice_session_id");
+
+-- AddForeignKey
+ALTER TABLE "practice_session_retrospectives" ADD CONSTRAINT "practice_session_retrospectives_practice_session_id_fkey" FOREIGN KEY ("practice_session_id") REFERENCES "practice_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,10 +192,25 @@ model PracticeSession {
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
 
-  sectionItems PracticeSessionSectionItem[]
+  sectionItems  PracticeSessionSectionItem[]
+  retrospective PracticeSessionRetrospective?
 
   @@index([seasonId, scheduledAt])
   @@map("practice_sessions")
+}
+
+model PracticeSessionRetrospective {
+  id                String          @id @default(uuid())
+  practiceSession   PracticeSession @relation(fields: [practiceSessionId], references: [id], onDelete: Cascade)
+  practiceSessionId String          @unique @map("practice_session_id")
+  participantCount  Int             @map("participant_count")
+  summary           String          @db.Text
+  wentWell          String?         @map("went_well") @db.Text
+  improvements      String?         @db.Text
+  createdAt         DateTime        @default(now()) @map("created_at")
+  updatedAt         DateTime        @updatedAt @map("updated_at")
+
+  @@map("practice_session_retrospectives")
 }
 
 model PracticeSessionSectionItem {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -215,5 +215,17 @@
     "invalidEmail": "Invalid email address",
     "tooShort": "Too short",
     "tooLong": "Too long"
+  },
+  "retrospective": {
+    "title": "Retrospective",
+    "add": "Add retrospective",
+    "emptyHint": "No retrospective has been written for this session yet.",
+    "participantCount": "Participant count",
+    "summary": "What we did",
+    "wentWell": "What went well",
+    "improvements": "What to improve",
+    "deleteTitle": "Delete retrospective",
+    "deleteConfirm": "Are you sure you want to delete this retrospective? This action cannot be undone.",
+    "hasRetro": "Has retrospective"
   }
 }

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -215,5 +215,17 @@
     "invalidEmail": "Virheellinen sähköpostiosoite",
     "tooShort": "Liian lyhyt",
     "tooLong": "Liian pitkä"
+  },
+  "retrospective": {
+    "title": "Retrospektiivi",
+    "add": "Lisää retrospektiivi",
+    "emptyHint": "Tälle harjoituskerralle ei ole vielä kirjattu retrospektiiviä.",
+    "participantCount": "Osallistujien määrä",
+    "summary": "Mitä teimme",
+    "wentWell": "Mikä meni hyvin",
+    "improvements": "Mitä voisi parantaa",
+    "deleteTitle": "Poista retrospektiivi",
+    "deleteConfirm": "Haluatko varmasti poistaa tämän retrospektiivin? Tätä toimintoa ei voi perua.",
+    "hasRetro": "Sisältää retrospektiivin"
   }
 }

--- a/tests/schemas/retrospective.test.ts
+++ b/tests/schemas/retrospective.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { retrospectiveSchema, retrospectiveFormSchema } from '~/schemas/retrospective';
+
+describe('retrospectiveSchema (server-side, transforming)', () => {
+  it('parses valid input and transforms participantCount to a number', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '12',
+      summary: 'We worked on putting and threw a few rounds.',
+      wentWell: 'Energy was high.',
+      improvements: 'Need more variety in warm-up.',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.participantCount).toBe(12);
+    expect(typeof result.data.participantCount).toBe('number');
+    expect(result.data.summary).toBe('We worked on putting and threw a few rounds.');
+    expect(result.data.wentWell).toBe('Energy was high.');
+    expect(result.data.improvements).toBe('Need more variety in warm-up.');
+  });
+
+  it('accepts participantCount = 0 (rained out / no-show)', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '0',
+      summary: 'Cancelled due to thunderstorm.',
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.participantCount).toBe(0);
+  });
+
+  it('accepts participantCount = 100 (upper bound)', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '100',
+      summary: 'Big tournament practice.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects participantCount above 100', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '101',
+      summary: 'Test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative participantCount', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '-1',
+      summary: 'Test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer participantCount', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '12.5',
+      summary: 'Test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-numeric participantCount', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: 'twelve',
+      summary: 'Test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty participantCount', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '',
+      summary: 'Test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty summary', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '5',
+      summary: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only summary', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '5',
+      summary: '   \n  ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('trims surrounding whitespace from summary', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '5',
+      summary: '   Worked on putting.   ',
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.summary).toBe('Worked on putting.');
+  });
+
+  it('treats empty wentWell as undefined', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '5',
+      summary: 'Did the thing.',
+      wentWell: '',
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.wentWell).toBeUndefined();
+  });
+
+  it('treats whitespace-only improvements as undefined', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '5',
+      summary: 'Did the thing.',
+      improvements: '   ',
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.improvements).toBeUndefined();
+  });
+
+  it('omits wentWell and improvements when not provided', () => {
+    const result = retrospectiveSchema.safeParse({
+      participantCount: '5',
+      summary: 'Did the thing.',
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.wentWell).toBeUndefined();
+    expect(result.data.improvements).toBeUndefined();
+  });
+});
+
+describe('retrospectiveFormSchema (client-side, no transforms)', () => {
+  it('accepts valid string inputs without transforming participantCount', () => {
+    const result = retrospectiveFormSchema.safeParse({
+      participantCount: '14',
+      summary: 'Did stuff.',
+      wentWell: '',
+      improvements: '',
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.participantCount).toBe('14');
+    expect(typeof result.data.participantCount).toBe('string');
+  });
+
+  it('rejects out-of-range participantCount', () => {
+    const result = retrospectiveFormSchema.safeParse({
+      participantCount: '500',
+      summary: 'Anything',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only summary', () => {
+    const result = retrospectiveFormSchema.safeParse({
+      participantCount: '5',
+      summary: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/services/retrospectives.test.ts
+++ b/tests/services/retrospectives.test.ts
@@ -158,9 +158,7 @@ describe('retrospectives service', () => {
     });
 
     it('throws when deleting a non-existent retrospective', async () => {
-      await expect(
-        deleteRetrospective('00000000-0000-0000-0000-000000000000')
-      ).rejects.toThrow();
+      await expect(deleteRetrospective('00000000-0000-0000-0000-000000000000')).rejects.toThrow();
     });
   });
 

--- a/tests/services/retrospectives.test.ts
+++ b/tests/services/retrospectives.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../setup/db-setup';
+import {
+  createRetrospective,
+  deleteRetrospective,
+  fetchRetrospectiveBySessionId,
+  updateRetrospective,
+} from '~/services/retrospectives.server';
+
+async function createSessionFixture(slug = 'test-session') {
+  return db.practiceSession.create({
+    data: {
+      slug,
+      name: 'Test session',
+      sessionLength: 90,
+    },
+  });
+}
+
+describe('retrospectives service', () => {
+  beforeEach(async () => {
+    // The global setup truncates exercise_types CASCADE, which clears
+    // dependent rows but not practice_sessions itself. Clear it here so
+    // each test starts from a clean slate.
+    await db.practiceSessionRetrospective.deleteMany({});
+    await db.practiceSession.deleteMany({});
+  });
+
+  describe('createRetrospective', () => {
+    it('creates a retrospective for a session', async () => {
+      const session = await createSessionFixture();
+
+      const created = await createRetrospective(session.id, {
+        participantCount: 12,
+        summary: 'Worked on putting and approach throws.',
+        wentWell: 'Energy was high.',
+        improvements: 'Need more variety in warm-up.',
+      });
+
+      expect(created.id).toBeTruthy();
+      expect(created.practiceSessionId).toBe(session.id);
+      expect(created.participantCount).toBe(12);
+      expect(created.summary).toBe('Worked on putting and approach throws.');
+      expect(created.wentWell).toBe('Energy was high.');
+      expect(created.improvements).toBe('Need more variety in warm-up.');
+      expect(created.createdAt).toBeInstanceOf(Date);
+      expect(created.updatedAt).toBeInstanceOf(Date);
+
+      const inDb = await db.practiceSessionRetrospective.findUnique({
+        where: { id: created.id },
+      });
+      expect(inDb).not.toBeNull();
+    });
+
+    it('persists null for omitted optional fields', async () => {
+      const session = await createSessionFixture();
+
+      const created = await createRetrospective(session.id, {
+        participantCount: 0,
+        summary: 'Cancelled, only two showed up.',
+      });
+
+      expect(created.wentWell).toBeNull();
+      expect(created.improvements).toBeNull();
+    });
+
+    it('rejects a second retrospective for the same session (unique constraint)', async () => {
+      const session = await createSessionFixture();
+
+      await createRetrospective(session.id, {
+        participantCount: 10,
+        summary: 'First retro.',
+      });
+
+      await expect(
+        createRetrospective(session.id, {
+          participantCount: 11,
+          summary: 'Second attempt — should fail.',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('rejects retrospective for a non-existent session', async () => {
+      await expect(
+        createRetrospective('00000000-0000-0000-0000-000000000000', {
+          participantCount: 5,
+          summary: 'Should fail (FK constraint).',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('updateRetrospective', () => {
+    it('updates fields on an existing retrospective', async () => {
+      const session = await createSessionFixture();
+      const created = await createRetrospective(session.id, {
+        participantCount: 8,
+        summary: 'Original summary',
+        wentWell: 'Original wentWell',
+      });
+
+      const updated = await updateRetrospective(created.id, {
+        participantCount: 14,
+        summary: 'Updated summary',
+        wentWell: 'Updated wentWell',
+        improvements: 'New improvement notes',
+      });
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.participantCount).toBe(14);
+      expect(updated.summary).toBe('Updated summary');
+      expect(updated.wentWell).toBe('Updated wentWell');
+      expect(updated.improvements).toBe('New improvement notes');
+    });
+
+    it('clears optional fields when undefined is passed', async () => {
+      const session = await createSessionFixture();
+      const created = await createRetrospective(session.id, {
+        participantCount: 8,
+        summary: 'Sum',
+        wentWell: 'Originally set',
+        improvements: 'Originally set',
+      });
+
+      const updated = await updateRetrospective(created.id, {
+        participantCount: 8,
+        summary: 'Sum',
+      });
+
+      expect(updated.wentWell).toBeNull();
+      expect(updated.improvements).toBeNull();
+    });
+
+    it('throws when updating a non-existent retrospective', async () => {
+      await expect(
+        updateRetrospective('00000000-0000-0000-0000-000000000000', {
+          participantCount: 1,
+          summary: 'x',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('deleteRetrospective', () => {
+    it('removes a retrospective by id', async () => {
+      const session = await createSessionFixture();
+      const created = await createRetrospective(session.id, {
+        participantCount: 5,
+        summary: 'To be deleted',
+      });
+
+      await deleteRetrospective(created.id);
+
+      const after = await db.practiceSessionRetrospective.findUnique({
+        where: { id: created.id },
+      });
+      expect(after).toBeNull();
+    });
+
+    it('throws when deleting a non-existent retrospective', async () => {
+      await expect(
+        deleteRetrospective('00000000-0000-0000-0000-000000000000')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('fetchRetrospectiveBySessionId', () => {
+    it('returns the retrospective when one exists for the session', async () => {
+      const session = await createSessionFixture();
+      const created = await createRetrospective(session.id, {
+        participantCount: 7,
+        summary: 'lookup',
+      });
+
+      const fetched = await fetchRetrospectiveBySessionId(session.id);
+      expect(fetched).not.toBeNull();
+      expect(fetched?.id).toBe(created.id);
+    });
+
+    it('returns null when the session has no retrospective', async () => {
+      const session = await createSessionFixture();
+
+      const fetched = await fetchRetrospectiveBySessionId(session.id);
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe('cascade delete behaviour', () => {
+    it('removes the retrospective when its parent session is deleted', async () => {
+      const session = await createSessionFixture();
+      const created = await createRetrospective(session.id, {
+        participantCount: 5,
+        summary: 'Should be cascade-deleted.',
+      });
+
+      await db.practiceSession.delete({ where: { id: session.id } });
+
+      const after = await db.practiceSessionRetrospective.findUnique({
+        where: { id: created.id },
+      });
+      expect(after).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a coach-internal retrospective for each practice session, per the
spec refined via the `grill-me` skill (see `docs/prompts/Exercise
retrospective.md`) and the architectural decisions captured in
`docs/adr/0008-practice-session-retrospective.md`.

Closes #60.

- New `PracticeSessionRetrospective` model with `@unique` FK
  (enforces 0..1 cardinality) and `onDelete: Cascade`.
- Inline UI on the session detail page: empty CTA → render → edit →
  delete-with-confirmation. No separate routes, no slug — deliberate
  departure from the per-resource CRUD convention; rationale in the
  ADR.
- Indicator badge on the practice sessions list shows which sessions
  already have a retrospective.
- `react-md-editor` reused for both the editor and the rendered view.
- Repository queries follow ADR-0007 (one query per file).
- Zod schema split into a non-transforming `retrospectiveFormSchema`
  (client RHF resolver) and a transforming `retrospectiveSchema`
  (server-side parsing), matching the existing `exercise.ts` pattern.
- i18n strings added for fi (default) and en. The project supports
  `fi`/`en` only per `app/i18nextOptions.ts`.

## Privacy note

Retrospectives are coach-internal and must never be exposed on a
public/unauthenticated surface. Today the app has no auth, so this is
captured in ADR-0008 as a **release-blocking constraint**: before any
public deployment, retros must be hidden behind authentication. No env
flag was added — the durable mechanism is the ADR + the eventual auth
work.

## Commits (per-slice history)

1. ADR-0008 (Proposed)
2. Prisma model + migration
3. Repository queries (4 files + include update)
4. Zod schema (form + server)
5. Service + route action wiring + UI + i18n
6. Sessions-list indicator
7. Tests (schema + service)
8. Prettier formatting

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run format` clean
- [x] `npm test` — 113/113 passing (84 prior + 17 schema + 12 service)
- [ ] Manual smoke test: open a session → add retro → save → edit →
      save → delete → confirm → indicator appears/disappears on the
      sessions list correctly
- [ ] Verify markdown rendering matches the exercise content style
- [ ] Verify validation messages show correctly when participantCount
      is empty / out of range / non-integer, and when summary is empty

## Reviewer focus

Per CLAUDE.md, please review **ADR-0008** before merging — the key
decisions to sign off on:

1. Inline subresource pattern (no slug, no separate routes).
2. Privacy as a release-blocker rather than a today-flag.
3. `@unique` enforcement of 0..1 cardinality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
